### PR TITLE
Add support for oauth token and a way to see my organizations

### DIFF
--- a/src/main/java/org/kohsuke/github/GitHub.java
+++ b/src/main/java/org/kohsuke/github/GitHub.java
@@ -42,10 +42,13 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 
 import static org.codehaus.jackson.annotate.JsonAutoDetect.Visibility.*;
 
@@ -75,12 +78,15 @@ public class GitHub {
             encodedAuthorization = null;
     }
 
-    private GitHub (String oauthAccessToken) {
-		this.login = null;
+    private GitHub (String oauthAccessToken) throws IOException {
+    	
 		this.password = null;
 		this.encodedAuthorization = null;
 		
 		this.oauthAccessToken = oauthAccessToken;
+		
+		this.login = getMyself().getLogin();
+		
     	
     }
     /**
@@ -106,7 +112,7 @@ public class GitHub {
         return new GitHub(login,apiToken,password);
     }
 
-    public static GitHub connectUsingOAuth (String accessToken) {
+    public static GitHub connectUsingOAuth (String accessToken) throws IOException {
     	return new GitHub(accessToken);
     }
     /**
@@ -234,6 +240,10 @@ public class GitHub {
         return o;
     }
 
+    public Map<String, GHOrganization> getMyOrganizations() throws IOException {
+    	 return retrieveWithAuth("/organizations",JsonOrganizations.class).wrap(this);
+        
+    }
     /**
      * Gets the {@link GHUser} that represents yourself.
      */

--- a/src/main/java/org/kohsuke/github/JsonOrganizations.java
+++ b/src/main/java/org/kohsuke/github/JsonOrganizations.java
@@ -1,0 +1,44 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2010, Kohsuke Kawaguchi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.kohsuke.github;
+
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * 
+ */
+class JsonOrganizations {
+    public List<GHOrganization> organizations;
+
+    public Map<String,GHOrganization> wrap(GitHub root) {
+        Map<String,GHOrganization> map = new TreeMap<String, GHOrganization>();
+        for (GHOrganization o : organizations) {
+            o.root = root;
+            map.put(o.getLogin(),o);
+        }
+        return map;
+    }
+}


### PR DESCRIPTION
I've written a github oauth authentication plugin for jenkins and I used github-api for the interactions with github once I have the token.

My first pass implementation of the plugin works so I want to contribute the github-api changes back.

Changes:
1. setup the Github class using the oauth token.
2. get a list of organizations that the **current** user belongs to.
