### PR TITLE
Fix getMyOrganizations to build hash on `login` instead of `name`

### DIFF
--- a/src/main/java/org/kohsuke/github/GitHub.java
+++ b/src/main/java/org/kohsuke/github/GitHub.java
@@ -419,7 +419,7 @@ public class GitHub {
         GHOrganization[] orgs = retrieveWithAuth("/user/orgs", GHOrganization[].class);
         Map<String, GHOrganization> r = new HashMap<String, GHOrganization>();
         for (GHOrganization o : orgs) {
-            r.put(o.name,o.wrapUp(this));
+            r.put(o.getLogin(),o.wrapUp(this));
         }
         return r;
     }


### PR DESCRIPTION
In v3, orgs always have a `login`, but the `name` is only returned on the detailed call. `getMyOrganizations()` was keying on `name`, but was always `null`. This is to change it to `login` as the unique id for orgs.
