### PR TITLE
Using pagination when getting Pull Requests from a repository

### DIFF
--- a/src/main/java/org/kohsuke/github/GHOrganization.java
+++ b/src/main/java/org/kohsuke/github/GHOrganization.java
@@ -129,7 +129,7 @@ public class GHOrganization extends GHPerson {
     public List<GHPullRequest> getPullRequests() throws IOException {
         List<GHPullRequest> all = new ArrayList<GHPullRequest>();
         for (GHRepository r : getRepositoriesWithOpenPullRequests()) {
-            all.addAll(r.getPullRequests(GHIssueState.OPEN));
+            all.addAll(r.getPullRequests(GHIssueState.OPEN).iterator().asList());
         }
         return all;
     }

--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -359,11 +359,18 @@ public class GHRepository {
     /**
      * Retrieves all the pull requests of a particular state.
      */
-    public List<GHPullRequest> getPullRequests(GHIssueState state) throws IOException {
-        GHPullRequest[] r = root.retrieveWithAuth("/repos/" + owner.login + '/' + name + "/pulls?state=" + state.name().toLowerCase(Locale.ENGLISH), GHPullRequest[].class);
-        for (GHPullRequest p : r)
-            p.wrapUp(this);
-        return new ArrayList<GHPullRequest>(Arrays.asList(r));
+    public PagedIterable<GHPullRequest> getPullRequests(final GHIssueState state) {
+        return new PagedIterable<GHPullRequest>() {
+            public PagedIterator<GHPullRequest> iterator() {
+                return new PagedIterator<GHPullRequest>(root.retrievePaged(String.format("/repos/%s/%s/pulls?state=%s", owner.login,name,state.name().toLowerCase(Locale.ENGLISH)), GHPullRequest[].class, false)) {
+                    @Override
+                    protected void wrapUp(GHPullRequest[] page) {
+                        for (GHPullRequest pr : page)
+                            pr.wrap(GHRepository.this);
+                    }
+                };
+            };
+        };
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/PagedIterator.java
+++ b/src/main/java/org/kohsuke/github/PagedIterator.java
@@ -1,5 +1,6 @@
 package org.kohsuke.github;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -8,7 +9,8 @@ import java.util.List;
  * Iterator over a pagenated data source.
  *
  * Aside from the normal iterator operation, this method exposes {@link #nextPage()}
- * that allows the caller to retrieve items per page.
+ * that allows the caller to retrieve items per page and {@link #asList()}
+ * that allows the caller to retrieve all items at once.
  *
  * @author Kohsuke Kawaguchi
  */
@@ -59,6 +61,17 @@ public abstract class PagedIterator<T> implements Iterator<T> {
         r = r.subList(pos,r.size());
         current = null;
         pos = 0;
+        return r;
+    }
+
+    /**
+     * Gets a list of all items
+     */
+    public List<T> asList() {
+        List<T> r = new ArrayList<T>();
+        for(Iterator i = this; i.hasNext();) {
+            r.addAll(nextPage());
+        }
         return r;
     }
 }

--- a/src/test/java/org/kohsuke/AppTest.java
+++ b/src/test/java/org/kohsuke/AppTest.java
@@ -14,11 +14,13 @@ import org.kohsuke.github.GHKey;
 import org.kohsuke.github.GHMyself;
 import org.kohsuke.github.GHOrganization;
 import org.kohsuke.github.GHOrganization.Permission;
+import org.kohsuke.github.GHPullRequest;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GHTeam;
 import org.kohsuke.github.GHUser;
 import org.kohsuke.github.GitHub;
 import org.kohsuke.github.PagedIterable;
+import org.kohsuke.github.PagedIterator;
 
 import java.io.IOException;
 import java.net.URL;
@@ -62,6 +64,17 @@ public class AppTest extends TestCase {
         assertEquals("master",r.getMasterBranch());
         r.getPullRequest(1);
         r.getPullRequests(GHIssueState.OPEN);
+    }
+
+    public void testFetchPullRequestAsList() throws Exception {
+        GitHub gh = GitHub.connect();
+        GHRepository r = gh.getOrganization("symfony").getRepository("symfony-docs");
+        assertEquals("master", r.getMasterBranch());
+        PagedIterator<GHPullRequest> i = r.getPullRequests(GHIssueState.CLOSED).iterator();
+        List<GHPullRequest> prs = i.asList();
+        assertNotNull(prs);
+        assertTrue(prs.size() > 0);
+        assertFalse(i.hasNext());
     }
 
     public void testRepoPermissions() throws Exception {


### PR DESCRIPTION
Hi,

   As Pull Request API is paginate in the Github API v3, I propose to modify the GHPullRequest getter to return a PagedIterator instead of a simple List.

   I didn't knew if I need to maintain the List signature so, instead, I write a new method in PagedIterator that allow to fetch all items at once.

I'll be happy if you can look a it :)

Thanks

Aurélien
