### PR TITLE
JENKINS-13726: Github plugin should work with Github enterprise by allowing for overriding the github URL.

### DIFF
--- a/src/main/java/org/kohsuke/github/GitHub.java
+++ b/src/main/java/org/kohsuke/github/GitHub.java
@@ -118,6 +118,10 @@ public class GitHub {
         return new GitHub(props.getProperty("login"),props.getProperty("token"),props.getProperty("password"));
     }
 
+    public static GitHub connect(String githubServer, String login, String apiToken, String password){
+        return new GitHub(githubServer,login,apiToken,password);
+    }
+
     public static GitHub connect(String login, String apiToken){
         return new GitHub(login,apiToken,null);
     }
@@ -153,10 +157,20 @@ public class GitHub {
     		tailApiUrl = tailApiUrl +  (tailApiUrl.indexOf('?')>=0 ?'&':'?') + "access_token=" + oauthAccessToken;
     	}
 
-        if (tailApiUrl.startsWith("/"))
-            return new URL("https://api."+githubServer+tailApiUrl);
-        else
+        if (tailApiUrl.startsWith("/")) {
+            if ("github.com".equals(githubServer)) {
+                return new URL("https://api." + githubServer + tailApiUrl);
+            } else {
+                // use protocol if defined otherwise default to https.
+                if (githubServer.matches("^(https?)://.*$")) {
+                    return new URL(githubServer + "/api/v3" + tailApiUrl);
+                } else {
+                    return new URL("https://" + githubServer + "/api/v3" + tailApiUrl);
+                }
+            }
+        } else {
             return new URL(tailApiUrl);
+        }
     }
 
     /*package*/ Requester retrieve() {

--- a/src/test/java/org/kohsuke/github/GitHubTest.java
+++ b/src/test/java/org/kohsuke/github/GitHubTest.java
@@ -1,0 +1,29 @@
+package org.kohsuke.github;
+
+import junit.framework.TestCase;
+
+/**
+ * Unit test for {@link GitHub}.
+ */
+public class GitHubTest extends TestCase {
+
+    public void testGitHubServerWithHttp() throws Exception {
+        GitHub hub = GitHub.connect("http://enterprise.kohsuke.org", "kohsuke", "token", "password");
+        assertEquals("http://enterprise.kohsuke.org/api/v3/test", hub.getApiURL("/test").toString());
+    }
+
+    public void testGitHubServerWithHttps() throws Exception {
+        GitHub hub = GitHub.connect("https://enterprise.kohsuke.org", "kohsuke", "token", "password");
+        assertEquals("https://enterprise.kohsuke.org/api/v3/test", hub.getApiURL("/test").toString());
+    }
+
+    public void testGitHubServerWithoutProtocol() throws Exception {
+        GitHub hub = GitHub.connect("enterprise.kohsuke.org", "kohsuke", "token", "password");
+        assertEquals("https://enterprise.kohsuke.org/api/v3/test", hub.getApiURL("/test").toString());
+    }
+
+    public void testGitHubServerWithoutServer() throws Exception {
+        GitHub hub = GitHub.connect("kohsuke", "token", "password");
+        assertEquals("https://api.github.com/test", hub.getApiURL("/test").toString());
+    }
+}


### PR DESCRIPTION
For supporting standalone github enterprise servers.
