### PR TITLE
Commit's short info model

### DIFF
--- a/src/main/java/org/kohsuke/github/GHCommit.java
+++ b/src/main/java/org/kohsuke/github/GHCommit.java
@@ -186,7 +186,7 @@ public class GHCommit {
     
     
 
-    public GHCommitShortInfo getCommit() {
+    public GHCommitShortInfo getCommitShortInfo() {
 		return commit;
 	}
 

--- a/src/main/java/org/kohsuke/github/GHCompare.java
+++ b/src/main/java/org/kohsuke/github/GHCompare.java
@@ -84,10 +84,10 @@ public class GHCompare {
      */
     public static class Commit extends GHCommit {
 
-        private InnerCommit innerCommit;
+        private InnerCommit commit;
 
-        public InnerCommit getInnerCommit() {
-            return innerCommit;
+        public InnerCommit getCommit() {
+            return commit;
         }
     }
 

--- a/src/test/java/org/kohsuke/AppTest.java
+++ b/src/test/java/org/kohsuke/AppTest.java
@@ -335,8 +335,8 @@ public class AppTest extends TestCase {
     
     public void testCommitShortInfo() throws Exception {
         GHCommit commit = gitHub.getUser("kohsuke").getRepository("test").getCommit("c77360d6f2ff2c2e6dd11828ad5dccf72419fa1b");
-        assertEquals(commit.getCommit().getAuthor().getName(), "Kohsuke Kawaguchi");
-        assertEquals(commit.getCommit().getMessage(), "Added a file");
+        assertEquals(commit.getCommitShortInfo().getAuthor().getName(), "Kohsuke Kawaguchi");
+        assertEquals(commit.getCommitShortInfo().getMessage(), "Added a file");
     }
 
     public void testPullRequestPopulate() throws Exception {


### PR DESCRIPTION
Github api returns commit info in this way:
{
    "sha": "c77360d6f2ff2c2e6dd11828ad5dccf72419fa1b",
    "commit": {
      "author": {
        "name": "Kohsuke Kawaguchi",
        "email": "kk@kohsuke.org",
        "date": "2012-04-11T16:23:37Z"
      },
      "committer": {
        "name": "Kohsuke Kawaguchi",
        "email": "kk@kohsuke.org",
        "date": "2012-04-11T16:23:37Z"
      },
      "message": "Added a file",
      "tree": {
        "sha": "496d6428b9cf92981dc9495211e6e1120fb6f2ba",
        "url": "https://api.github.com/repos/kohsuke/test/git/trees/496d6428b9cf92981dc9495211e6e1120fb6f2ba"
      },
      "url": "https://api.github.com/repos/kohsuke/test/git/commits/c77360d6f2ff2c2e6dd11828ad5dccf72419fa1b",
      "comment_count": 0
    }, ...

github-api updated wuth necessary models in order to wrap new info
