### PR TITLE
Use `PagedIterator<GHIssue>` to retrieve repository issues

### DIFF
--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -143,7 +143,24 @@ public class GHRepository {
     }
 
     public List<GHIssue> getIssues(GHIssueState state) throws IOException {
-        return Arrays.asList(GHIssue.wrap(root.retrieve().to("/repos/" + owner.login + "/" + name + "/issues?state=" + state.toString().toLowerCase(), GHIssue[].class), this));
+        return listIssues(state).asList();
+    }
+
+    /**
+     * Lists up all the issues in this repository.
+     */
+    public PagedIterable<GHIssue> listIssues(final GHIssueState state) {
+        return new PagedIterable<GHIssue>() {
+            public PagedIterator<GHIssue> iterator() {
+                return new PagedIterator<GHIssue>(root.retrieve().asIterator(getApiTailUrl("issues?state="+state.toString().toLowerCase(Locale.ENGLISH)), GHIssue[].class)) {
+                    @Override
+                    protected void wrapUp(GHIssue[] page) {
+                        for (GHIssue c : page)
+                            c.wrap(GHRepository.this);
+                    }
+                };
+            }
+        };
     }
 
     public GHReleaseBuilder createRelease(String tag) {

--- a/src/test/java/org/kohsuke/AppTest.java
+++ b/src/test/java/org/kohsuke/AppTest.java
@@ -79,6 +79,12 @@ public class AppTest extends TestCase {
         o.close();
     }
 
+    public void testGetIssues() throws Exception {
+        List<GHIssue> closedIssues = gitHub.getUser("kohsuke").getRepository("github-api").getIssues(GHIssueState.CLOSED);
+        // prior to using PagedIterable GHRepository.getIssues(GHIssueState) would only retrieve 30 issues
+        assertTrue(closedIssues.size() > 30);
+    }
+
     public void testRateLimit() throws IOException {
         System.out.println(gitHub.getRateLimit());
     }


### PR DESCRIPTION
Overcomes default 30 item page size limit.

Fixes #55 
