### PR TITLE
Add support for PULL_REQUEST_REVIEW_COMMENT event types.

### DIFF
--- a/src/main/java/org/kohsuke/github/GHEvent.java
+++ b/src/main/java/org/kohsuke/github/GHEvent.java
@@ -22,6 +22,7 @@ public enum GHEvent {
     MEMBER,
     PUBLIC,
     PULL_REQUEST,
+    PULL_REQUEST_REVIEW_COMMENT,
     PUSH,
     TEAM_ADD,
     WATCH


### PR DESCRIPTION
EventInfo.getType() would return a GHEvent with the GHEvent.type field set to "PULL_REQUEST_REVIEW_COMMENT_EVENT", but since PULL_REQUEST_REVIEW_COMMENT was not present in GHEvent, GHEvent.getType() would fail.
