### PR TITLE
Fetching of user's verified keys through standard OAuth scope.

### DIFF
--- a/src/main/java/org/kohsuke/github/GHKey.java
+++ b/src/main/java/org/kohsuke/github/GHKey.java
@@ -10,9 +10,9 @@ import org.apache.commons.lang.builder.ToStringBuilder;
 public class GHKey {
     /*package almost final*/ GitHub root;
 
-    private String url, key, title;
-    private boolean verified;
-    private int id;
+    protected String url, key, title;
+    protected boolean verified;
+    protected int id;
 
     public int getId() {
         return id;

--- a/src/main/java/org/kohsuke/github/GHMyself.java
+++ b/src/main/java/org/kohsuke/github/GHMyself.java
@@ -34,12 +34,30 @@ public class GHMyself extends GHUser {
     /**
      * Returns the read-only list of all the pulic keys of the current user.
      *
+     * NOTE: When using OAuth authenticaiton, the READ/WRITE User scope is
+     * required by the GitHub APIs, otherwise you will get a 404 NOT FOUND.
+     *
      * @return
      *      Always non-null.
      */
     public List<GHKey> getPublicKeys() throws IOException {
         return Collections.unmodifiableList(Arrays.asList(root.retrieve().to("/user/keys", GHKey[].class)));
     }
+
+    /**
+     * Returns the read-only list of all the pulic verified keys of the current user.
+     *
+     * Differently from the getPublicKeys() method, the retrieval of the user's
+     * verified public keys does not require any READ/WRITE OAuth Scope to the
+     * user's profile.
+     *
+     * @return
+     *      Always non-null.
+     */
+  public List<GHVerifiedKey> getPublicVerifiedKeys() throws IOException {
+    return Collections.unmodifiableList(Arrays.asList(root.retrieve().to(
+        "/users/" + getLogin() + "/keys", GHVerifiedKey[].class)));
+  }
 
     /**
      * Gets the organization that this user belongs to.

--- a/src/main/java/org/kohsuke/github/GHVerifiedKey.java
+++ b/src/main/java/org/kohsuke/github/GHVerifiedKey.java
@@ -1,0 +1,13 @@
+package org.kohsuke.github;
+
+public class GHVerifiedKey extends GHKey {
+
+  public GHVerifiedKey() {
+    this.verified = true;
+  }
+
+  @Override
+  public String getTitle() {
+    return (title == null ? "key-" + id : title);
+  }
+}


### PR DESCRIPTION
Allow the fetching of a user's verified key list without
requiring to have an OAuth user scope (which implies
user's profile READ/WRITE permissions).
This would relax the requirements of GitHub OAuth scope
when fetching public information such as their SSH
public keys.
