### PR TITLE
Un-finalize GHContent.

### DIFF
--- a/src/main/java/org/kohsuke/github/GHContent.java
+++ b/src/main/java/org/kohsuke/github/GHContent.java
@@ -9,7 +9,7 @@ import javax.xml.bind.DatatypeConverter;
  *
  * @author Alexandre COLLIGNON
  */
-public final class GHContent {
+public class GHContent {
     private GHRepository owner;
 
     private String type;


### PR DESCRIPTION
GHContent was declared as a final class, which makes it impossible to mock with libraries like Mockito.

This PR un-finalizes it so it's mock-able.
