### PR TITLE
Cast url.openConnection() to HttpURLConnection instead of HttpsURLConnec...

### DIFF
--- a/src/main/java/org/kohsuke/github/Requester.java
+++ b/src/main/java/org/kohsuke/github/Requester.java
@@ -25,7 +25,6 @@ package org.kohsuke.github;
 
 import org.apache.commons.io.IOUtils;
 
-import javax.net.ssl.HttpsURLConnection;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -294,7 +293,7 @@ class Requester {
 
 
     private HttpURLConnection setupConnection(URL url) throws IOException {
-        HttpsURLConnection uc = (HttpsURLConnection) url.openConnection();
+        HttpURLConnection uc = (HttpURLConnection) url.openConnection();
 
         // if the authentication is needed but no credential is given, try it anyway (so that some calls
         // that do work with anonymous access in the reduced form should still work.)


### PR DESCRIPTION
...tion. Useful for enterprise githubs which does not have https set up.

Hi Koshuke,

Please accept this pull request if this makes sense to you.

Thanks
Prasanna
