### PR TITLE
add listTeams method on GHOrganization

### DIFF
--- a/src/main/java/org/kohsuke/github/GHOrganization.java
+++ b/src/main/java/org/kohsuke/github/GHOrganization.java
@@ -128,6 +128,24 @@ public class GHOrganization extends GHPerson {
     }
 
     /**
+     * All the teams of this organization.
+     */
+    public PagedIterable<GHTeam> listTeams() throws IOException {
+        return new PagedIterable<GHTeam>() {
+            public PagedIterator<GHTeam> iterator() {
+                return new PagedIterator<GHTeam>(root.retrieve().asIterator(String.format("/orgs/%s/teams", login), GHTeam[].class)) {
+                    @Override
+                    protected void wrapUp(GHTeam[] teams) {
+                    	for(GHTeam t: teams) {
+                    		t.org = GHOrganization.this;
+                    	}
+                    }
+                };
+            }
+        };
+    }
+
+    /**
      * Conceals the membership.
      */
     public void conceal(GHUser u) throws IOException {


### PR DESCRIPTION
The existing method getTeams does not retrieve all teams due to the paging of the REST API.

So I added a listTeams method in the GHOrganization API, using the same pattern as the existing listMembers (use of PagedIterable).
