### PR TITLE
Add support for retriving a single ref

### DIFF
--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -561,7 +561,19 @@ public class GHRepository {
     public GHRef[] getRefs(String refType) throws IOException {
         return root.retrieve().to(String.format("/repos/%s/%s/git/refs/%s", owner.login, name, refType), GHRef[].class);
     }
-
+    /**
+	 * Retrive a ref of the given type for the current GitHub repository.
+	 * 
+	 * @param refName
+	 *            eg: heads/branch
+	 * @return refs matching the request type
+	 * @throws IOException
+	 *             on failure communicating with GitHub, potentially due to an
+	 *             invalid ref type being requested
+	 */
+	public GHRef getRef(String refName) throws IOException {
+		return root.retrieve().to(String.format("/repos/%s/%s/git/refs/%s", owner.login, name, refName), GHRef.class);
+	}
     /**
      * Gets a commit object in this repository.
      */

--- a/src/test/java/org/kohsuke/github/AppTest.java
+++ b/src/test/java/org/kohsuke/github/AppTest.java
@@ -530,6 +530,12 @@ public class AppTest extends AbstractGitHubApiTestBase {
     }
 
     @Test
+	public void testRef() throws IOException {
+		GHRef masterRef = gitHub.getRepository("jenkinsci/jenkins").getRef("heads/master");
+		assertEquals("https://api.github.com/repos/jenkinsci/jenkins/git/refs/heads/master", masterRef.getUrl().toString());
+	}
+
+    @Test
     public void directoryListing() throws IOException {
         List<GHContent> children = gitHub.getRepository("jenkinsci/jenkins").getDirectoryContent("core");
         for (GHContent c : children) {


### PR DESCRIPTION
Implements the following api method
https://developer.github.com/v3/git/refs/#get-a-reference
