### PR TITLE
Un-finalize a handful of classes.

### DIFF
--- a/src/main/java/org/kohsuke/github/GHContentUpdateResponse.java
+++ b/src/main/java/org/kohsuke/github/GHContentUpdateResponse.java
@@ -4,7 +4,7 @@ package org.kohsuke.github;
  * The response that is returned when updating
  * repository content.
 **/
-public final class GHContentUpdateResponse {
+public class GHContentUpdateResponse {
     private GHContent content;
     private GHCommit commit;
 

--- a/src/main/java/org/kohsuke/github/GHGist.java
+++ b/src/main/java/org/kohsuke/github/GHGist.java
@@ -17,7 +17,7 @@ import java.util.Map.Entry;
  * @see GitHub#getGist(String)
  * @see GitHub#createGist()
  */
-public final class GHGist {
+public class GHGist {
     /*package almost final*/ GHUser owner;
     /*package almost final*/ GitHub root;
 

--- a/src/main/java/org/kohsuke/github/GHHook.java
+++ b/src/main/java/org/kohsuke/github/GHHook.java
@@ -10,7 +10,7 @@ import java.util.Map;
 /**
  * @author Kohsuke Kawaguchi
  */
-public final class GHHook {
+public class GHHook {
     /**
      * Repository that the hook belongs to.
      */

--- a/src/main/java/org/kohsuke/github/GHPersonSet.java
+++ b/src/main/java/org/kohsuke/github/GHPersonSet.java
@@ -9,7 +9,7 @@ import java.util.HashSet;
  * 
  * @author Kohsuke Kawaguchi
  */
-public final class GHPersonSet<T extends GHPerson> extends HashSet<T> {
+public class GHPersonSet<T extends GHPerson> extends HashSet<T> {
     public GHPersonSet() {
     }
 


### PR DESCRIPTION
Having final classes prevents consumers of the API from mocking those classes in testing. I've un-finalized a handful of classes in this PR such that they will mock correctly for those people who are doing mocking work for unit tests.
