### PR TITLE
Update to OkHttp 2.0.0, which has a new OkUrlFactory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,8 +93,8 @@
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp</groupId>
-      <artifactId>okhttp</artifactId>
-      <version>1.5.3</version>
+      <artifactId>okhttp-urlconnection</artifactId>
+      <version>2.0.0</version>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/src/main/java/org/kohsuke/github/extras/OkHttpConnector.java
+++ b/src/main/java/org/kohsuke/github/extras/OkHttpConnector.java
@@ -1,6 +1,7 @@
 package org.kohsuke.github.extras;
 
 import com.squareup.okhttp.OkHttpClient;
+import com.squareup.okhttp.OkUrlFactory;
 import org.kohsuke.github.HttpConnector;
 
 import java.io.IOException;
@@ -19,13 +20,13 @@ import java.net.URL;
  * @author Kohsuke Kawaguchi
  */
 public class OkHttpConnector implements HttpConnector {
-    private final OkHttpClient client;
+    private final OkUrlFactory urlFactory;
 
-    public OkHttpConnector(OkHttpClient client) {
-        this.client = client;
+    public OkHttpConnector(OkUrlFactory urlFactory) {
+        this.urlFactory = urlFactory;
     }
 
     public HttpURLConnection connect(URL url) throws IOException {
-        return client.open(url);
+        return urlFactory.open(url);
     }
 }


### PR DESCRIPTION
OkHttp changed API with v2.0.0, and the `client.open(url)` method no longer exists:

"URLConnection support has moved to the okhttp-urlconnection module. If you're upgrading from 1.x, this change will impact you. You will need to add the okhttp-urlconnection module to your project and use
the OkUrlFactory to create new instances of HttpURLConnection"

https://github.com/square/okhttp/blob/master/CHANGELOG.md#version-200-rc1
