### PR TITLE
Implement pagination on list of private+public repos of a user.

### DIFF
--- a/src/main/java/org/kohsuke/github/GHMyself.java
+++ b/src/main/java/org/kohsuke/github/GHMyself.java
@@ -101,12 +101,24 @@ public class GHMyself extends GHUser {
      * Lists up all repositories this user owns (public and private).
      *
      * Unlike {@link #getAllRepositories()}, this does not wait until all the repositories are returned.
+     * Repositories are returned by GitHub API with a 30 items per page.
      */
     @Override
     public PagedIterable<GHRepository> listRepositories() {
+      return listRepositories(30);
+    }
+
+    /**
+     * Lists up all the repositories this user owns (public and private) using the specified page size.
+     *
+     * @param pageSize size for each page of items returned by GitHub. Maximum page size is 100.
+     *
+     * Unlike {@link #getRepositories()}, this does not wait until all the repositories are returned.
+     */
+    public PagedIterable<GHRepository> listRepositories(final int pageSize) {
         return new PagedIterable<GHRepository>() {
             public PagedIterator<GHRepository> iterator() {
-                return new PagedIterator<GHRepository>(root.retrieve().asIterator("/user/repos", GHRepository[].class)) {
+                return new PagedIterator<GHRepository>(root.retrieve().asIterator("/user/repos?per_page=" + pageSize, GHRepository[].class)) {
                     @Override
                     protected void wrapUp(GHRepository[] page) {
                         for (GHRepository c : page)


### PR DESCRIPTION
The paginated version of listRepositories() was 
missing at GHMyself: as side-effect of this bug
when requesting a paginated list of repositories
the ones privately owned by a user were not shown.

This was caused by the missing override of the 
listRepositories(final int pageSize) at GHMyself
that caused the GHPerson implementation to invoked.

The GHPerson version uses the /users/:org/repos?per_page=x
URL which _works fine_ for organisations but unfortunately
_does not return_ private repositories for users.

IMHO GitHub API are quite inconsistent form this 
point of view, but they are documented in this way
so that work (inconsistently) as designed.
