### PR TITLE
Add missing GitHub event types.

### DIFF
--- a/src/main/java/org/kohsuke/github/GHEvent.java
+++ b/src/main/java/org/kohsuke/github/GHEvent.java
@@ -12,6 +12,8 @@ public enum GHEvent {
     COMMIT_COMMENT,
     CREATE,
     DELETE,
+    DEPLOYMENT,
+    DEPLOYMENT_STATUS,
     DOWNLOAD,
     FOLLOW,
     FORK,
@@ -25,6 +27,8 @@ public enum GHEvent {
     PULL_REQUEST,
     PULL_REQUEST_REVIEW_COMMENT,
     PUSH,
+    RELEASE,
+    STATUS,
     TEAM_ADD,
     WATCH
 }


### PR DESCRIPTION
This adds the missing GitHub `DEPLOYMENT`, `DEPLOYMENT_STATUS`, `RELEASE` and `STATUS` events.

I'm running into this:

```
Exception in thread "main" java.lang.IllegalArgumentException: No enum constant org.kohsuke.github.GHEvent.RELEASE
```
