### PR TITLE
Remove getPath()

### DIFF
--- a/src/main/java/org/kohsuke/github/GHPullRequest.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequest.java
@@ -196,7 +196,7 @@ public class GHPullRequest extends GHIssue {
         return new PagedIterable<GHPullRequestCommitDetail>() {
             public PagedIterator<GHPullRequestCommitDetail> iterator() {
                 return new PagedIterator<GHPullRequestCommitDetail>(root.retrieve().asIterator(
-                        String.format("%s/commits", getApiURL().getPath()),
+                        String.format("%s/commits", getApiURL()),
                         GHPullRequestCommitDetail[].class)) {
                     @Override
                     protected void wrapUp(GHPullRequestCommitDetail[] page) {


### PR DESCRIPTION
When getting the path and providing an enterprise url for the apiUrl, the /api/v3 portion gets duplicated.  Since they will be combined on line 231 of GitHub.java there is no point just grabbing the path.  See https://github.com/janinko/ghprb/issues/178, and https://issues.jenkins-ci.org/browse/JENKINS-24145?focusedCommentId=208270#comment-208270
