### PR TITLE
Use issues endpoints for pull requests

### DIFF
--- a/src/main/java/org/kohsuke/github/GHIssue.java
+++ b/src/main/java/org/kohsuke/github/GHIssue.java
@@ -163,6 +163,10 @@ public class GHIssue {
         new Requester(root)._with(key, value).method("PATCH").to(getApiRoute());
     }
 
+    private void editIssue(String key, Object value) throws IOException {
+        new Requester(root)._with(key, value).method("PATCH").to(getIssuesApiRoute());
+    }
+
     /**
      * Closes this issue.
      */
@@ -186,11 +190,11 @@ public class GHIssue {
     }
 
     public void assignTo(GHUser user) throws IOException {
-        edit("assignee",user.getLogin());
+        editIssue("assignee",user.getLogin());
     }
 
     public void setLabels(String... labels) throws IOException {
-        edit("labels",labels);
+        editIssue("labels",labels);
     }
 
     /**
@@ -222,7 +226,7 @@ public class GHIssue {
         return getIssuesApiRoute();
     }
 
-    private String getIssuesApiRoute() {
+    protected String getIssuesApiRoute() {
         return "/repos/"+owner.getOwnerName()+"/"+owner.getName()+"/issues/"+number;
     }
 

--- a/src/test/java/org/kohsuke/github/PullRequestTest.java
+++ b/src/test/java/org/kohsuke/github/PullRequestTest.java
@@ -3,17 +3,39 @@ package org.kohsuke.github;
 import org.junit.After;
 import org.junit.Test;
 
+import java.io.IOException;
+import java.util.Collection;
+
 /**
  * @author Kohsuke Kawaguchi
  */
 public class PullRequestTest extends AbstractGitHubApiTestBase {
     @Test
     public void createPullRequest() throws Exception {
-        GHRepository j = gitHub.getOrganization("github-api-test-org").getRepository("jenkins");
         String name = rnd.next();
-        GHPullRequest p = j.createPullRequest(name, "stable", "master", "## test");
+        GHPullRequest p = getRepository().createPullRequest(name, "stable", "master", "## test");
         System.out.println(p.getUrl());
         assertEquals(name, p.getTitle());
+    }
+
+    @Test // Requires push access to the test repo to pass
+    public void setLabels() throws Exception {
+        GHPullRequest p = getRepository().createPullRequest(rnd.next(), "stable", "master", "## test");
+        String label = rnd.next();
+        p.setLabels(label);
+
+        Collection<GHIssue.Label> labels = getRepository().getPullRequest(p.getNumber()).getLabels();
+        assertEquals(1, labels.size());
+        assertEquals(label, labels.iterator().next().getName());
+    }
+
+    @Test // Requires push access to the test repo to pass
+    public void setAssignee() throws Exception {
+        GHPullRequest p = getRepository().createPullRequest(rnd.next(), "stable", "master", "## test");
+        GHMyself user = gitHub.getMyself();
+        p.assignTo(user);
+
+        assertEquals(user, getRepository().getPullRequest(p.getNumber()).getAssignee());
     }
 
     @After
@@ -21,5 +43,9 @@ public class PullRequestTest extends AbstractGitHubApiTestBase {
         for (GHPullRequest pr : getRepository().getPullRequests(GHIssueState.OPEN)) {
             pr.close();
         }
+    }
+
+    private GHRepository getRepository() throws IOException {
+        return gitHub.getOrganization("github-api-test-org").getRepository("jenkins");
     }
 }


### PR DESCRIPTION
Setting labels and assignee on Pull requests failed silently, because the API endpoint being hit contained '/pulls/' rather than '/issues/'.

> "Every pull request is an issue, but not every issue is a pull request. For this reason, “shared” actions for both features, like manipulating assignees, labels and milestones, are provided within the Issues API."

https://developer.github.com/v3/pulls/#labels-assignees-and-milestones
