### PR TITLE
Allow to use custom HttpConnector when only OAuth token is given

### DIFF
--- a/src/main/java/org/kohsuke/github/GitHub.java
+++ b/src/main/java/org/kohsuke/github/GitHub.java
@@ -103,10 +103,13 @@ public class GitHub {
      *      Secret OAuth token.
      * @param password
      *      User's password. Always used in conjunction with the {@code login} parameter
+     * @param connector
+     *      HttpConnector to use. Pass null to use default connector.
      */
-    /* package */ GitHub(String apiUrl, String login, String oauthAccessToken, String password) throws IOException {
+    /* package */ GitHub(String apiUrl, String login, String oauthAccessToken, String password, HttpConnector connector) throws IOException {
         if (apiUrl.endsWith("/")) apiUrl = apiUrl.substring(0, apiUrl.length()-1); // normalize
         this.apiUrl = apiUrl;
+        if (null != connector) this.connector = connector;
 
         if (oauthAccessToken!=null) {
             encodedAuthorization = "token "+oauthAccessToken;

--- a/src/main/java/org/kohsuke/github/GitHubBuilder.java
+++ b/src/main/java/org/kohsuke/github/GitHubBuilder.java
@@ -15,6 +15,7 @@ public class GitHubBuilder {
     private String user;
     private String password;
     private String oauthToken;
+    private HttpConnector connector;
 
     public GitHubBuilder() {
     }
@@ -56,8 +57,12 @@ public class GitHubBuilder {
         this.user = user;
         return this;
     }
+    public GitHubBuilder withConnector(HttpConnector connector) {
+        this.connector = connector;
+        return this;
+    }
 
     public GitHub build() throws IOException {
-        return new GitHub(endpoint, user, oauthToken, password);
+        return new GitHub(endpoint, user, oauthToken, password, connector);
     }
 }


### PR DESCRIPTION
The old pull request is #120.

If you use `GitHub.connectUsingOAuth(String oauthAccessToken)` or `GitHub.connectUsingOAuth(String githubServer, String oauthAccessToken)`, the constructor of `GitHub` calls `#getMyself`.
Because there is no way to call `#setConnector` before the construction, `#getMyself` will fail if the server is behind proxies.
This pull request allows library users to use custom HttpConnector when only OAuth token is given.

Example usage is:

``` java
GitHub gh = new GitHubBuilder()
    .withEndpoint(serverAPIUrl)
    .withOAuthToken(accessToken)
    .withConnector(new HttpConnectorWithJenkinsProxy())
    .build();
```
