### PR TITLE
Allow pullRequest.getHead().getRepository().getCommit(headSha1) to work

### DIFF
--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -514,7 +514,7 @@ public class GHRepository {
                     @Override
                     protected void wrapUp(GHPullRequest[] page) {
                         for (GHPullRequest pr : page)
-                            pr.wrap(GHRepository.this);
+                            pr.wrapUp(GHRepository.this);
                     }
                 };
             }


### PR DESCRIPTION
The wrong .wrap method was used for pull requests initialized by state
(GHRepository.getPullReqests).

The wrong wrap call was introduced in 9fd34aec7fe9fa1359418c92b0a14526f837a4a4

This commit sets it back to the .wrapUp method which makes sure the pull request
substructure has the repo object set properly.

Without this change a NullPointerException is thrown on the last line of this
code because the repo object inside of the remoteRepository object is null:

GHRepository repo = github.getRepository(targetRepository);

List<GHPullRequest> openPullRequests = repo.getPullRequests(GHIssueState.OPEN);

for (GHPullRequest pullRequest : openPullRequests) {

```
GHCommitPointer head = pullRequest.getHead();

GHRepository remoteRepository = head.getRepository();

String commitId = head.getSha();

GHCommit headCommit = remoteRepository.getCommit(commitId);
```
