### PR TITLE
Put mockito in the test scope.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,7 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
       <version>1.9.5</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <repositories>


### PR DESCRIPTION
I was having issues in a downstream project from github-api where mockito was appearing on the classpath where it shouldn't. I ran some dependency analysis and found that the inclusion was because of its mention in github-api without the test scope designation.
