### PR TITLE
Update mockito-all to test scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,7 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
       <version>1.9.5</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <repositories>


### PR DESCRIPTION
Set scope to test for mockito-all to avoid forcing downstream projects
to include it.
