### PR TITLE
Consider header rate limit information for getRateLimit()

### DIFF
--- a/src/main/java/org/kohsuke/github/GitHubClient.java
+++ b/src/main/java/org/kohsuke/github/GitHubClient.java
@@ -224,7 +224,7 @@ abstract class GitHubClient {
         try {
             result = fetch(JsonRateLimit.class, "/rate_limit").resources;
         } catch (FileNotFoundException e) {
-            // GitHub Enterprise doesn't have the rate_limit endpoint
+            // For some versions of GitHub Enterprise, the rate_limit endpoint returns a 404.
             // However some newer versions of GHE include rate limit header information
             // Use that if available
             result = lastRateLimit();

--- a/src/test/resources/org/kohsuke/github/GHRateLimitTest/wiremock/testGitHubEnterpriseDoesNotHaveRateLimit/mappings/rate_limit-2.json
+++ b/src/test/resources/org/kohsuke/github/GHRateLimitTest/wiremock/testGitHubEnterpriseDoesNotHaveRateLimit/mappings/rate_limit-2.json
@@ -1,0 +1,41 @@
+{
+  "id": "445e28ce-5a3d-4014-ae8a-041e2e73312d",
+  "name": "rate_limit",
+  "request": {
+    "url": "/rate_limit",
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
+  },
+  "response": {
+    "status": 404,
+    "body": "{\"message\":\"Not Found\",\"documentation_url\":\"https://developer.github.com/v3\"}",
+    "headers": {
+      "Date": "{{now timezone='GMT' format='EEE, dd MMM yyyy HH:mm:ss z'}}",
+      "Content-Type": "application/json; charset=utf-8",
+      "Server": "GitHub.com",
+      "Status": "404 Not Found",
+      "X-OAuth-Scopes": "admin:org, admin:org_hook, admin:public_key, admin:repo_hook, delete_repo, gist, notifications, repo, user, write:discussion",
+      "X-Accepted-OAuth-Scopes": "repo",
+      "X-GitHub-Media-Type": "unknown, github.v3",
+      "Access-Control-Expose-Headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type",
+      "Access-Control-Allow-Origin": "*",
+      "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",
+      "X-Frame-Options": "deny",
+      "X-Content-Type-Options": "nosniff",
+      "X-XSS-Protection": "1; mode=block",
+      "Referrer-Policy": "origin-when-cross-origin, strict-origin-when-cross-origin",
+      "Content-Security-Policy": "default-src 'none'",
+      "X-GitHub-Request-Id": "C913:6B2C:1031322:13844FD:5D9B706C"
+    }
+  },
+  "uuid": "445e28ce-5a3d-4014-ae8a-041e2e73312d",
+  "persistent": true,
+  "scenarioName": "rate-limit",
+  "requiredScenarioState": "Started",
+  "newScenarioState": "rate-limit-1",
+  "insertionIndex": 2
+}

--- a/src/test/resources/org/kohsuke/github/GHRateLimitTest/wiremock/testGitHubEnterpriseDoesNotHaveRateLimit/mappings/rate_limit-3.json
+++ b/src/test/resources/org/kohsuke/github/GHRateLimitTest/wiremock/testGitHubEnterpriseDoesNotHaveRateLimit/mappings/rate_limit-3.json
@@ -1,0 +1,41 @@
+{
+  "id": "445e28ce-5a3d-4014-ae8a-041e2e73312d",
+  "name": "rate_limit",
+  "request": {
+    "url": "/rate_limit",
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
+  },
+  "response": {
+    "status": 404,
+    "body": "{\"message\":\"Not Found\",\"documentation_url\":\"https://developer.github.com/v3\"}",
+    "headers": {
+      "Date": "{{now timezone='GMT' format='EEE, dd MMM yyyy HH:mm:ss z'}}",
+      "Content-Type": "application/json; charset=utf-8",
+      "Server": "GitHub.com",
+      "Status": "404 Not Found",
+      "X-OAuth-Scopes": "admin:org, admin:org_hook, admin:public_key, admin:repo_hook, delete_repo, gist, notifications, repo, user, write:discussion",
+      "X-Accepted-OAuth-Scopes": "repo",
+      "X-GitHub-Media-Type": "unknown, github.v3",
+      "Access-Control-Expose-Headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type",
+      "Access-Control-Allow-Origin": "*",
+      "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",
+      "X-Frame-Options": "deny",
+      "X-Content-Type-Options": "nosniff",
+      "X-XSS-Protection": "1; mode=block",
+      "Referrer-Policy": "origin-when-cross-origin, strict-origin-when-cross-origin",
+      "Content-Security-Policy": "default-src 'none'",
+      "X-GitHub-Request-Id": "C913:6B2C:1031322:13844FD:5D9B706C"
+    }
+  },
+  "uuid": "445e28ce-5a3d-4014-ae8a-041e2e73312d",
+  "persistent": true,
+  "scenarioName": "rate-limit",
+  "requiredScenarioState": "rate-limit-1",
+  "newScenarioState": "rate-limit-2",
+  "insertionIndex": 3
+}

--- a/src/test/resources/org/kohsuke/github/GHRateLimitTest/wiremock/testGitHubEnterpriseDoesNotHaveRateLimit/mappings/rate_limit-4.json
+++ b/src/test/resources/org/kohsuke/github/GHRateLimitTest/wiremock/testGitHubEnterpriseDoesNotHaveRateLimit/mappings/rate_limit-4.json
@@ -34,5 +34,8 @@
   },
   "uuid": "445e28ce-5a3d-4014-ae8a-041e2e73312d",
   "persistent": true,
-  "insertionIndex": 2
+  "scenarioName": "rate-limit",
+  "requiredScenarioState": "rate-limit-2",
+  "newScenarioState": "rate-limit-3",
+  "insertionIndex": 4
 }

--- a/src/test/resources/org/kohsuke/github/GHRateLimitTest/wiremock/testGitHubEnterpriseDoesNotHaveRateLimit/mappings/rate_limit-5.json
+++ b/src/test/resources/org/kohsuke/github/GHRateLimitTest/wiremock/testGitHubEnterpriseDoesNotHaveRateLimit/mappings/rate_limit-5.json
@@ -1,0 +1,44 @@
+{
+  "id": "445e28ce-5a3d-4014-ae8a-041e2e73312d",
+  "name": "rate_limit",
+  "request": {
+    "url": "/rate_limit",
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
+  },
+  "response": {
+    "status": 404,
+    "body": "{\"message\":\"Not Found\",\"documentation_url\":\"https://developer.github.com/v3\"}",
+    "headers": {
+      "Date": "{{now timezone='GMT' format='EEE, dd MMM yyyy HH:mm:ss z'}}",
+      "Content-Type": "application/json; charset=utf-8",
+      "Server": "GitHub.com",
+      "Status": "404 Not Found",
+      "X-RateLimit-Limit": "5000",
+      "X-RateLimit-Remaining": "4967",
+      "X-RateLimit-Reset": "{{testStartDate offset='1 hours' format='unix'}}",
+      "X-OAuth-Scopes": "admin:org, admin:org_hook, admin:public_key, admin:repo_hook, delete_repo, gist, notifications, repo, user, write:discussion",
+      "X-Accepted-OAuth-Scopes": "repo",
+      "X-GitHub-Media-Type": "unknown, github.v3",
+      "Access-Control-Expose-Headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type",
+      "Access-Control-Allow-Origin": "*",
+      "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",
+      "X-Frame-Options": "deny",
+      "X-Content-Type-Options": "nosniff",
+      "X-XSS-Protection": "1; mode=block",
+      "Referrer-Policy": "origin-when-cross-origin, strict-origin-when-cross-origin",
+      "Content-Security-Policy": "default-src 'none'",
+      "X-GitHub-Request-Id": "C913:6B2C:1031322:13844FD:5D9B706C"
+    }
+  },
+  "uuid": "445e28ce-5a3d-4014-ae8a-041e2e73312d",
+  "persistent": true,
+  "scenarioName": "rate-limit",
+  "requiredScenarioState": "rate-limit-3",
+  "newScenarioState": "rate-limit-4",
+  "insertionIndex": 5
+}


### PR DESCRIPTION
# Description 
When `getRateLimit()` call gets a 404 response, use the header rate limit information if it is available.  

Fixes #802

@timja Could you take a look at this? 

# Before submitting a PR:
We love getting PRs, but we hate asking people for the same basic changes every time. 

- [x] Push your changes to a branch other than `master`. Create your PR from that branch.    
- [x] Add JavaDocs and other comments
- [x] Write tests that run and pass in CI. See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to capture snapshot data.
- [x] Run `mvn clean compile` locally. This may reformat your code, commit those changes.
- [x] Run `mvn -D enable-ci clean install site` locally. If this command doesn't succeed, your change will not pass CI.

