### PR TITLE
Fix tag template in release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,5 @@
 name-template: 'v$NEXT_PATCH_VERSION 🌈'
-tag-template: 'v$NEXT_PATCH_VERSION'
+tag-template: 'github-api-$NEXT_MINOR_VERSION'
 categories:
   - title: '🚀 Features'
     labels:


### PR DESCRIPTION
The draft tag was using the wrong tag format, (not the one created by the maven release plugin that is currently setup)