### PR TITLE
Workaround for GitBucket refs issue

### DIFF
--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -1607,7 +1607,11 @@ public class GHRepository extends GHObject {
         }
 
         // Verify that the ref returned is the one requested
-        if (result == null || !result.getRef().equals("refs/" + refName)) {
+        // Used .endsWith(refName) instead of .equals("refs/" + refName) to workaround a GitBucket
+        // issue where the "ref" field omits the "refs/" prefix. "endsWith()" is functionally
+        // the same for this scenario - the server refs matching is prefix-based, so
+        // a ref that ends with the correct string will always be the correct one.
+        if (result == null || !result.getRef().endsWith(refName)) {
             throw new GHFileNotFoundException(String.format("git/refs/%s", refName)
                     + " {\"message\":\"Not Found\",\"documentation_url\":\"https://developer.github.com/v3/git/refs/#get-a-reference\"}");
         }


### PR DESCRIPTION
# Description 
The bug that caused this has been fixed by GitBucket but may not be released for some time.
It was a change to this library that broke them, so to be nice we're fully working around it here.

That said, the GET /refs endpoint is deprecated and will be going away at some point.
We will be making a breaking change in this area again in the next few months. We'll need to raise
it to GitBucket to make sure they handle it proproperly.

# Before submitting a PR:
We love getting PRs, but we hate asking people for the same basic changes every time. 

- [x] Push your changes to a branch other than `master`. Create your PR from that branch.    
- [x] Add JavaDocs and other comments
- [x] Write tests that run and pass in CI. See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to capture snapshot data.
- [x] Run `mvn clean compile` locally. This may reformat your code, commit those changes.
- [x] Run `mvn -D enable-ci clean install site` locally. If this command doesn't succeed, your change will not pass CI.

# When creating a PR: 

- [x] Fill in the "Description" above. 
- [x] Enable "Allow edits from maintainers". 
