### PR TITLE
GHPullRequest.getLabels should not go to the GHIssue API endpoint

### DIFF
--- a/src/main/java/org/kohsuke/github/GHIssue.java
+++ b/src/main/java/org/kohsuke/github/GHIssue.java
@@ -158,10 +158,8 @@ public class GHIssue extends GHObject implements Reactable {
      * Gets labels.
      *
      * @return the labels
-     * @throws IOException
-     *             the io exception
      */
-    public Collection<GHLabel> getLabels() throws IOException {
+    public Collection<GHLabel> getLabels() {
         if (labels == null) {
             return Collections.emptyList();
         }

--- a/src/main/java/org/kohsuke/github/GHPullRequest.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequest.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -72,13 +71,6 @@ public class GHPullRequest extends GHIssue implements Refreshable {
     // pull request reviewers
     private GHUser[] requested_reviewers;
     private GHTeam[] requested_teams;
-
-    /**
-     * GitHub doesn't return some properties of {@link GHIssue} when requesting the GET on the 'pulls' API route as
-     * opposed to 'issues' API route. This flag remembers whether we made the GET call on the 'issues' route on this
-     * object to fill in those missing details
-     */
-    private transient boolean fetchedIssueDetails;
 
     GHPullRequest wrapUp(GHRepository owner) {
         this.wrap(owner);
@@ -176,12 +168,6 @@ public class GHPullRequest extends GHIssue implements Refreshable {
      */
     public Date getMergedAt() {
         return GitHubClient.parseDate(merged_at);
-    }
-
-    @Override
-    public Collection<GHLabel> getLabels() throws IOException {
-        fetchIssue();
-        return super.getLabels();
     }
 
     @Override
@@ -662,10 +648,4 @@ public class GHPullRequest extends GHIssue implements Refreshable {
         MERGE, SQUASH, REBASE
     }
 
-    private void fetchIssue() throws IOException {
-        if (!fetchedIssueDetails) {
-            root.createRequest().withUrlPath(getIssuesApiRoute()).fetchInto(this);
-            fetchedIssueDetails = true;
-        }
-    }
 }


### PR DESCRIPTION
@jvz found that the Jenkins label filter plugin does not work with App authentication. After https://github.com/jenkinsci/github-branch-source-plugin/pull/351 + https://github.com/jenkinsci/github-label-filter-plugin/pull/4 I think I figured out the problem: the lookup of PR labels—and only this method—uses https://developer.github.com/v3/issues/#get-an-issue rather than https://developer.github.com/v3/pulls/#get-a-pull-request as you might expect. Presumably the fact that the App is configured to permit https://developer.github.com/v3/apps/permissions/#permission-on-pull-requests but not https://developer.github.com/v3/apps/permissions/#permission-on-issues makes this not work. I tracked this weird logic down to 372d5ff7581b9cdca6510c47a579433b291d814b from 2014 which has little explanation and may have been a workaround for some transient bug in GH long since fixed; I get the expected metadata today with either endpoint (using a PAT):

```console
$ curl -u $AUTH -s https://api.github.com/repos/jenkinsci/mercurial-plugin/issues/150 | jq .labels
[
  {
    "id": 1447091401,
    "node_id": "MDU6TGFiZWwxNDQ3MDkxNDAx",
    "url": "https://api.github.com/repos/jenkinsci/mercurial-plugin/labels/test",
    "name": "test",
    "color": "1c6c87",
    "default": false,
    "description": ""
  }
]
$ curl -u $AUTH -s https://api.github.com/repos/jenkinsci/mercurial-plugin/pulls/150 | jq .labels
[
  {
    "id": 1447091401,
    "node_id": "MDU6TGFiZWwxNDQ3MDkxNDAx",
    "url": "https://api.github.com/repos/jenkinsci/mercurial-plugin/labels/test",
    "name": "test",
    "color": "1c6c87",
    "default": false,
    "description": ""
  }
]
```

_Possibly_ fixes https://github.com/jenkinsci/github-label-filter-plugin/issues/3 (not yet verified).