### PR TITLE
GH docs have moved, adjust assertion accordingly.

### DIFF
--- a/src/test/java/org/kohsuke/github/WireMockStatusReporterTest.java
+++ b/src/test/java/org/kohsuke/github/WireMockStatusReporterTest.java
@@ -125,7 +125,7 @@ public class WireMockStatusReporterTest extends AbstractGitHubWireMockTest {
         assertThat(e, Matchers.<Exception>instanceOf(GHFileNotFoundException.class));
         assertThat(e.getMessage(),
                 containsString(
-                        "{\"message\":\"Not Found\",\"documentation_url\":\"https://developer.github.com/v3/repos/#get\"}"));
+                        "{\"message\":\"Not Found\",\"documentation_url\":\"https://docs.github.com/rest/reference/repos#get-a-repository\"}"));
     }
 
     @Test


### PR DESCRIPTION
Github have changed the location of docs so assertion was failing, updated according to their pointers on the old page.