### PR TITLE
Include assets directly in GHRelease

### DIFF
--- a/src/main/java/org/kohsuke/github/GHRelease.java
+++ b/src/main/java/org/kohsuke/github/GHRelease.java
@@ -261,7 +261,7 @@ public class GHRelease extends GHObject {
      */
     @Deprecated
     @Preview
-    public List<GHAsset> getCachedAssets() {
+    public List<GHAsset> assets() {
         return assets;
     }
 
@@ -272,7 +272,7 @@ public class GHRelease extends GHObject {
      * @throws IOException
      *             the io exception
      * @deprecated The behavior of this method will change in a future release. It will then provide cached assets as
-     *             provided by {@link #getCachedAssets()}. Use {@link #listAssets()} instead to fetch up-to-date
+     *             provided by {@link #assets()}. Use {@link #listAssets()} instead to fetch up-to-date
      *             information of assets.
      */
     @Deprecated

--- a/src/main/java/org/kohsuke/github/GHRelease.java
+++ b/src/main/java/org/kohsuke/github/GHRelease.java
@@ -15,6 +15,7 @@ import static java.lang.String.*;
  * Release in a github repository.
  *
  * @see GHRepository#getReleases() GHRepository#getReleases()
+ * @see GHRepository#listReleases() () GHRepository#listReleases()
  * @see GHRepository#createRelease(String) GHRepository#createRelease(String)
  */
 public class GHRelease extends GHObject {
@@ -23,6 +24,7 @@ public class GHRelease extends GHObject {
 
     private String html_url;
     private String assets_url;
+    private List<GHAsset> assets;
     private String upload_url;
     private String tag_name;
     private String target_commitish;
@@ -252,15 +254,9 @@ public class GHRelease extends GHObject {
      * Gets assets.
      *
      * @return the assets
-     * @throws IOException
-     *             the io exception
      */
-    public List<GHAsset> getAssets() throws IOException {
-        Requester builder = owner.root.createRequest();
-
-        return builder.withUrlPath(getApiTailUrl("assets"))
-                .toIterable(GHAsset[].class, item -> item.wrap(this))
-                .toList();
+    public List<GHAsset> getAssets() {
+        return assets;
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHRelease.java
+++ b/src/main/java/org/kohsuke/github/GHRelease.java
@@ -272,8 +272,8 @@ public class GHRelease extends GHObject {
      * @throws IOException
      *             the io exception
      * @deprecated The behavior of this method will change in a future release. It will then provide cached assets as
-     *             provided by {@link #assets()}. Use {@link #listAssets()} instead to fetch up-to-date
-     *             information of assets.
+     *             provided by {@link #assets()}. Use {@link #listAssets()} instead to fetch up-to-date information of
+     *             assets.
      */
     @Deprecated
     public List<GHAsset> getAssets() throws IOException {
@@ -289,8 +289,7 @@ public class GHRelease extends GHObject {
      */
     public PagedIterable<GHAsset> listAssets() throws IOException {
         Requester builder = owner.root.createRequest();
-        return builder.withUrlPath(getApiTailUrl("assets"))
-                .toIterable(GHAsset[].class, item -> item.wrap(this));
+        return builder.withUrlPath(getApiTailUrl("assets")).toIterable(GHAsset[].class, item -> item.wrap(this));
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHRelease.java
+++ b/src/main/java/org/kohsuke/github/GHRelease.java
@@ -260,6 +260,20 @@ public class GHRelease extends GHObject {
     }
 
     /**
+     * Re-fetch the assets of this release.
+     * 
+     * @return the assets
+     * @throws IOException
+     *             the io exception
+     */
+    public List<GHAsset> fetchAssets() throws IOException {
+        Requester builder = owner.root.createRequest();
+        return builder.withUrlPath(getApiTailUrl("assets"))
+                .toIterable(GHAsset[].class, item -> item.wrap(this))
+                .toList();
+    }
+
+    /**
      * Deletes this release.
      *
      * @throws IOException

--- a/src/main/java/org/kohsuke/github/GHRelease.java
+++ b/src/main/java/org/kohsuke/github/GHRelease.java
@@ -272,12 +272,12 @@ public class GHRelease extends GHObject {
      * @throws IOException
      *             the io exception
      * @deprecated The behavior of this method will change in a future release. It will then provide cached assets as
-     *             provided by {@link #getCachedAssets()}. Use {@link #fetchAssets()} instead to fetch up-to-date
+     *             provided by {@link #getCachedAssets()}. Use {@link #listAssets()} instead to fetch up-to-date
      *             information of assets.
      */
     @Deprecated
     public List<GHAsset> getAssets() throws IOException {
-        return fetchAssets();
+        return listAssets().toList();
     }
 
     /**
@@ -287,11 +287,10 @@ public class GHRelease extends GHObject {
      * @throws IOException
      *             the io exception
      */
-    public List<GHAsset> fetchAssets() throws IOException {
+    public PagedIterable<GHAsset> listAssets() throws IOException {
         Requester builder = owner.root.createRequest();
         return builder.withUrlPath(getApiTailUrl("assets"))
-                .toIterable(GHAsset[].class, item -> item.wrap(this))
-                .toList();
+                .toIterable(GHAsset[].class, item -> item.wrap(this));
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHRelease.java
+++ b/src/main/java/org/kohsuke/github/GHRelease.java
@@ -251,17 +251,38 @@ public class GHRelease extends GHObject {
     }
 
     /**
-     * Gets assets.
+     * Get the cached assets.
      *
      * @return the assets
+     *
+     * @deprecated This should be the default behavior of {@link #getAssets()} in a future release. This method is
+     *             introduced in addition to enable a transition to using cached asset information while keeping the
+     *             existing logic in place for backwards compatibility.
      */
-    public List<GHAsset> getAssets() {
+    @Deprecated
+    @Preview
+    public List<GHAsset> getCachedAssets() {
         return assets;
     }
 
     /**
      * Re-fetch the assets of this release.
-     * 
+     *
+     * @return the assets
+     * @throws IOException
+     *             the io exception
+     * @deprecated The behavior of this method will change in a future release. It will then provide cached assets as
+     *             provided by {@link #getCachedAssets()}. Use {@link #fetchAssets()} instead to fetch up-to-date
+     *             information of assets.
+     */
+    @Deprecated
+    public List<GHAsset> getAssets() throws IOException {
+        return fetchAssets();
+    }
+
+    /**
+     * Re-fetch the assets of this release.
+     *
      * @return the assets
      * @throws IOException
      *             the io exception

--- a/src/test/java/org/kohsuke/github/LifecycleTest.java
+++ b/src/test/java/org/kohsuke/github/LifecycleTest.java
@@ -45,7 +45,7 @@ public class LifecycleTest extends AbstractGitHubWireMockTest {
 
     private void updateAsset(GHRelease release, GHAsset asset) throws IOException {
         asset.setLabel("test label");
-        assertEquals("test label", release.getAssets().get(0).getLabel());
+        assertEquals("test label", release.fetchAssets().get(0).getLabel());
     }
 
     private void deleteAsset(GHRelease release, GHAsset asset) throws IOException {
@@ -56,7 +56,9 @@ public class LifecycleTest extends AbstractGitHubWireMockTest {
     private GHAsset uploadAsset(GHRelease release) throws IOException {
         GHAsset asset = release.uploadAsset(new File("LICENSE.txt"), "application/text");
         assertNotNull(asset);
-        List<GHAsset> assets = release.getAssets();
+        List<GHAsset> cachedAssets = release.getAssets();
+        assertEquals(0, cachedAssets.size());
+        List<GHAsset> assets = release.fetchAssets();
         assertEquals(1, assets.size());
         assertEquals("LICENSE.txt", assets.get(0).getName());
 

--- a/src/test/java/org/kohsuke/github/LifecycleTest.java
+++ b/src/test/java/org/kohsuke/github/LifecycleTest.java
@@ -45,7 +45,7 @@ public class LifecycleTest extends AbstractGitHubWireMockTest {
 
     private void updateAsset(GHRelease release, GHAsset asset) throws IOException {
         asset.setLabel("test label");
-        assertEquals("test label", release.fetchAssets().get(0).getLabel());
+        assertEquals("test label", release.getAssets().get(0).getLabel());
     }
 
     private void deleteAsset(GHRelease release, GHAsset asset) throws IOException {
@@ -58,7 +58,7 @@ public class LifecycleTest extends AbstractGitHubWireMockTest {
         assertNotNull(asset);
         List<GHAsset> cachedAssets = release.getCachedAssets();
         assertEquals(0, cachedAssets.size());
-        List<GHAsset> assets = release.fetchAssets();
+        List<GHAsset> assets = release.getAssets();
         assertEquals(1, assets.size());
         assertEquals("LICENSE.txt", assets.get(0).getName());
 

--- a/src/test/java/org/kohsuke/github/LifecycleTest.java
+++ b/src/test/java/org/kohsuke/github/LifecycleTest.java
@@ -50,7 +50,7 @@ public class LifecycleTest extends AbstractGitHubWireMockTest {
 
     private void deleteAsset(GHRelease release, GHAsset asset) throws IOException {
         asset.delete();
-        assertEquals(0, release.assets().size());
+        assertEquals(0, release.getAssets().size());
     }
 
     private GHAsset uploadAsset(GHRelease release) throws IOException {

--- a/src/test/java/org/kohsuke/github/LifecycleTest.java
+++ b/src/test/java/org/kohsuke/github/LifecycleTest.java
@@ -50,13 +50,13 @@ public class LifecycleTest extends AbstractGitHubWireMockTest {
 
     private void deleteAsset(GHRelease release, GHAsset asset) throws IOException {
         asset.delete();
-        assertEquals(0, release.getCachedAssets().size());
+        assertEquals(0, release.assets().size());
     }
 
     private GHAsset uploadAsset(GHRelease release) throws IOException {
         GHAsset asset = release.uploadAsset(new File("LICENSE.txt"), "application/text");
         assertNotNull(asset);
-        List<GHAsset> cachedAssets = release.getCachedAssets();
+        List<GHAsset> cachedAssets = release.assets();
         assertEquals(0, cachedAssets.size());
         List<GHAsset> assets = release.getAssets();
         assertEquals(1, assets.size());

--- a/src/test/java/org/kohsuke/github/LifecycleTest.java
+++ b/src/test/java/org/kohsuke/github/LifecycleTest.java
@@ -50,13 +50,13 @@ public class LifecycleTest extends AbstractGitHubWireMockTest {
 
     private void deleteAsset(GHRelease release, GHAsset asset) throws IOException {
         asset.delete();
-        assertEquals(0, release.getAssets().size());
+        assertEquals(0, release.getCachedAssets().size());
     }
 
     private GHAsset uploadAsset(GHRelease release) throws IOException {
         GHAsset asset = release.uploadAsset(new File("LICENSE.txt"), "application/text");
         assertNotNull(asset);
-        List<GHAsset> cachedAssets = release.getAssets();
+        List<GHAsset> cachedAssets = release.getCachedAssets();
         assertEquals(0, cachedAssets.size());
         List<GHAsset> assets = release.fetchAssets();
         assertEquals(1, assets.size());


### PR DESCRIPTION
# Description 

Resolves #528

Instead of doing a separate request to fetch the assets associated with
a release this keeps a local list of the assets that are part of the
list releases endpoint.

See https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#list-releases

The first commit c74fbbe expectedly fails at
```
[ERROR] Failures:
[ERROR]   LifecycleTest.testCreateRepository:39->uploadAsset:60->Assert.assertEquals:633->Assert.assertEquals:647->Assert.failNotEquals:835->Assert.fail:89 expected:<1> but was:<0>
```
as the call to `release.getAssets()` not returns the cached content instead of doing another request.

https://github.com/hub4j/github-api/blob/3a11b7ccbf5ef80e6231c15b539c5d386f827caf/src/test/java/org/kohsuke/github/LifecycleTest.java#L56-L64

Therefore, the second commit d881bf6 brings back the previous functionality as `fetchAssets()`. I don't know a better name for this, and I also don't know whether this should be an option or not.

The life cycle tests use the feature that retrieving the assets from a release actually does a roundtrip to Github and sends another request. This indicates that re-purposing `getAssets()` to be the cached access might cause problems on consumers that potentially rely on this assumption, too.