### PR TITLE
Deprecate OkHttp 2.x connector

### DIFF
--- a/src/main/java/org/kohsuke/github/extras/OkHttpConnector.java
+++ b/src/main/java/org/kohsuke/github/extras/OkHttpConnector.java
@@ -26,7 +26,11 @@ import javax.net.ssl.SSLSocketFactory;
  *
  * @author Roberto Tyley
  * @author Kohsuke Kawaguchi
+ * @deprecated This class depends on an unsupported version of OkHttp. Switch to
+ *             {@link org.kohsuke.github.extras.okhttp3.OkHttpConnector}.
+ * @see org.kohsuke.github.extras.okhttp3.OkHttpConnector
  */
+@Deprecated
 public class OkHttpConnector implements HttpConnector {
     private static final String HEADER_NAME = "Cache-Control";
     private final OkUrlFactory urlFactory;


### PR DESCRIPTION
OkHttp 2.x is unsupported.  OkHttpUrlFactory contains bugs and limiations which will not
be fixed and also cannot be mitigated by this library.  Users should move to OkHttp3.

Closes #997

# Before submitting a PR:
We love getting PRs, but we hate asking people for the same basic changes every time. 

- [ ] Push your changes to a branch other than `master`. Create your PR from that branch.    
- [ ] Add JavaDocs and other comments
- [ ] Write tests that run and pass in CI. See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to capture snapshot data.
- [ ] Run `mvn clean compile` locally. This may reformat your code, commit those changes.
- [ ] Run `mvn -D enable-ci clean install site` locally. If this command doesn't succeed, your change will not pass CI.

# When creating a PR: 

- [ ] Fill in the "Description" above. 
- [ ] Enable "Allow edits from maintainers". 
