### PR TITLE
Implement static typing for previews and clean up usage declarations

### DIFF
--- a/src/main/java/org/kohsuke/github/GHApp.java
+++ b/src/main/java/org/kohsuke/github/GHApp.java
@@ -189,7 +189,7 @@ public class GHApp extends GHObject {
      * @return a list of App installations
      * @see <a href="https://developer.github.com/v3/apps/#list-installations">List installations</a>
      */
-    @Preview
+    @Preview(MACHINE_MAN)
     @Deprecated
     public PagedIterable<GHAppInstallation> listInstallations() {
         return root.createRequest()
@@ -210,7 +210,7 @@ public class GHApp extends GHObject {
      *             on error
      * @see <a href="https://developer.github.com/v3/apps/#get-an-installation">Get an installation</a>
      */
-    @Preview
+    @Preview(MACHINE_MAN)
     @Deprecated
     public GHAppInstallation getInstallationById(long id) throws IOException {
         return root.createRequest()
@@ -233,7 +233,7 @@ public class GHApp extends GHObject {
      * @see <a href="https://developer.github.com/v3/apps/#get-an-organization-installation">Get an organization
      *      installation</a>
      */
-    @Preview
+    @Preview(MACHINE_MAN)
     @Deprecated
     public GHAppInstallation getInstallationByOrganization(String name) throws IOException {
         return root.createRequest()
@@ -258,7 +258,7 @@ public class GHApp extends GHObject {
      * @see <a href="https://developer.github.com/v3/apps/#get-a-repository-installation">Get a repository
      *      installation</a>
      */
-    @Preview
+    @Preview(MACHINE_MAN)
     @Deprecated
     public GHAppInstallation getInstallationByRepository(String ownerName, String repositoryName) throws IOException {
         return root.createRequest()
@@ -280,7 +280,7 @@ public class GHApp extends GHObject {
      *             on error
      * @see <a href="https://developer.github.com/v3/apps/#get-a-user-installation">Get a user installation</a>
      */
-    @Preview
+    @Preview(MACHINE_MAN)
     @Deprecated
     public GHAppInstallation getInstallationByUser(String name) throws IOException {
         return root.createRequest()

--- a/src/main/java/org/kohsuke/github/GHAppCreateTokenBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHAppCreateTokenBuilder.java
@@ -78,7 +78,7 @@ public class GHAppCreateTokenBuilder {
      * @throws IOException
      *             on error
      */
-    @Preview
+    @Preview(MACHINE_MAN)
     @Deprecated
     public GHAppInstallationToken create() throws IOException {
         return builder.method("POST")

--- a/src/main/java/org/kohsuke/github/GHAppInstallation.java
+++ b/src/main/java/org/kohsuke/github/GHAppInstallation.java
@@ -124,7 +124,7 @@ public class GHAppInstallation extends GHObject {
      *
      * @return the paged iterable
      */
-    @Preview
+    @Preview(MACHINE_MAN)
     @Deprecated
     public PagedSearchIterable<GHRepository> listRepositories() {
         GitHubRequest request;
@@ -322,7 +322,7 @@ public class GHAppInstallation extends GHObject {
      *             on error
      * @see <a href="https://developer.github.com/v3/apps/#delete-an-installation">Delete an installation</a>
      */
-    @Preview
+    @Preview(GAMBIT)
     @Deprecated
     public void deleteInstallation() throws IOException {
         root.createRequest()

--- a/src/main/java/org/kohsuke/github/GHBranch.java
+++ b/src/main/java/org/kohsuke/github/GHBranch.java
@@ -89,7 +89,7 @@ public class GHBranch {
      *
      * @return API URL that deals with the protection of this branch.
      */
-    @Preview
+    @Preview(Previews.LUKE_CAGE)
     @Deprecated
     public URL getProtectionUrl() {
         return GitHubClient.parseURL(protection_url);
@@ -102,6 +102,8 @@ public class GHBranch {
      * @throws IOException
      *             the io exception
      */
+    @Preview(Previews.LUKE_CAGE)
+    @Deprecated
     public GHBranchProtection getProtection() throws IOException {
         return root.createRequest()
                 .withPreview(Previews.LUKE_CAGE)
@@ -135,7 +137,7 @@ public class GHBranch {
      * @return GHBranchProtectionBuilder for enabling protection
      * @see GHCommitStatus#getContext() GHCommitStatus#getContext()
      */
-    @Preview
+    @Preview(Previews.LUKE_CAGE)
     @Deprecated
     public GHBranchProtectionBuilder enableProtection() {
         return new GHBranchProtectionBuilder(this);

--- a/src/main/java/org/kohsuke/github/GHBranchProtection.java
+++ b/src/main/java/org/kohsuke/github/GHBranchProtection.java
@@ -43,7 +43,7 @@ public class GHBranchProtection {
      * @throws IOException
      *             the io exception
      */
-    @Preview
+    @Preview(ZZZAX)
     @Deprecated
     public void enabledSignedCommits() throws IOException {
         requester().method("POST").withUrlPath(url + REQUIRE_SIGNATURES_URI).fetch(RequiredSignatures.class);
@@ -55,7 +55,7 @@ public class GHBranchProtection {
      * @throws IOException
      *             the io exception
      */
-    @Preview
+    @Preview(ZZZAX)
     @Deprecated
     public void disableSignedCommits() throws IOException {
         requester().method("DELETE").withUrlPath(url + REQUIRE_SIGNATURES_URI).send();
@@ -86,7 +86,7 @@ public class GHBranchProtection {
      * @throws IOException
      *             the io exception
      */
-    @Preview
+    @Preview(ZZZAX)
     @Deprecated
     public boolean getRequiredSignatures() throws IOException {
         return requester().withUrlPath(url + REQUIRE_SIGNATURES_URI).fetch(RequiredSignatures.class).enabled;

--- a/src/main/java/org/kohsuke/github/GHCheckRun.java
+++ b/src/main/java/org/kohsuke/github/GHCheckRun.java
@@ -298,7 +298,7 @@ public class GHCheckRun extends GHObject {
      * 
      * @return a builder which you should customize, then call {@link GHCheckRunBuilder#create}
      */
-    @Preview
+    @Preview(Previews.ANTIOPE)
     @Deprecated
     public @NonNull GHCheckRunBuilder update() {
         return new GHCheckRunBuilder(owner, getId());

--- a/src/main/java/org/kohsuke/github/GHCheckRunBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHCheckRunBuilder.java
@@ -46,7 +46,7 @@ import java.util.Locale;
  * @see <a href="https://developer.github.com/v3/checks/runs/#update-a-check-run">documentation</a>
  */
 @SuppressFBWarnings(value = "URF_UNREAD_FIELD", justification = "Jackson serializes these even without a getter")
-@Preview
+@Preview(Previews.ANTIOPE)
 @Deprecated
 public final class GHCheckRunBuilder {
 

--- a/src/main/java/org/kohsuke/github/GHCommit.java
+++ b/src/main/java/org/kohsuke/github/GHCommit.java
@@ -11,6 +11,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
+import static org.kohsuke.github.Previews.ANTIOPE;
 import static org.kohsuke.github.Previews.GROOT;
 
 /**
@@ -453,7 +454,7 @@ public class GHCommit {
      *
      * @return {@link PagedIterable} with the pull requests which contain this commit
      */
-    @Preview
+    @Preview(GROOT)
     @Deprecated
     public PagedIterable<GHPullRequest> listPullRequests() {
         return owner.root.createRequest()
@@ -469,7 +470,7 @@ public class GHCommit {
      * @throws IOException
      *             the io exception
      */
-    @Preview
+    @Preview(GROOT)
     @Deprecated
     public PagedIterable<GHBranch> listBranchesWhereHead() throws IOException {
         return owner.root.createRequest()
@@ -565,7 +566,7 @@ public class GHCommit {
      * @throws IOException
      *             on error
      */
-    @Preview
+    @Preview(ANTIOPE)
     @Deprecated
     public PagedIterable<GHCheckRun> getCheckRuns() throws IOException {
         return owner.getCheckRuns(sha);

--- a/src/main/java/org/kohsuke/github/GHCommitComment.java
+++ b/src/main/java/org/kohsuke/github/GHCommitComment.java
@@ -133,7 +133,7 @@ public class GHCommitComment extends GHObject implements Reactable {
                 .wrap(owner.root);
     }
 
-    @Preview
+    @Preview(SQUIRREL_GIRL)
     @Deprecated
     public PagedIterable<GHReaction> listReactions() {
         return owner.root.createRequest()

--- a/src/main/java/org/kohsuke/github/GHCommitSearchBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHCommitSearchBuilder.java
@@ -10,7 +10,7 @@ import java.io.IOException;
  * @author Marc de Verdelhan
  * @see GitHub#searchCommits() GitHub#searchCommits()
  */
-@Preview
+@Preview(Previews.CLOAK)
 @Deprecated
 public class GHCommitSearchBuilder extends GHSearchBuilder<GHCommit> {
     GHCommitSearchBuilder(GitHub root) {

--- a/src/main/java/org/kohsuke/github/GHCreateRepositoryBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHCreateRepositoryBuilder.java
@@ -3,7 +3,7 @@ package org.kohsuke.github;
 import java.io.IOException;
 import java.net.URL;
 
-import static org.kohsuke.github.Previews.BAPTISE;
+import static org.kohsuke.github.Previews.BAPTISTE;
 
 /**
  * Creates a repository
@@ -209,10 +209,10 @@ public class GHCreateRepositoryBuilder {
      *            true if enabled
      * @return a builder to continue with building
      */
-    @Preview
+    @Preview(BAPTISTE)
     @Deprecated
     public GHCreateRepositoryBuilder templateRepository(boolean enabled) {
-        this.builder.withPreview(BAPTISE);
+        this.builder.withPreview(BAPTISTE);
         this.builder.with("is_template", enabled);
         return this;
     }
@@ -239,10 +239,10 @@ public class GHCreateRepositoryBuilder {
      * @return a builder to continue with building
      * @see <a href="https://developer.github.com/v3/previews/">GitHub API Previews</a>
      */
-    @Preview
+    @Preview(BAPTISTE)
     @Deprecated
     public GHCreateRepositoryBuilder fromTemplateRepository(String templateOwner, String templateRepo) {
-        this.builder.withPreview(BAPTISE);
+        this.builder.withPreview(BAPTISTE);
         this.apiUrlTail = "/repos/" + templateOwner + "/" + templateRepo + "/generate";
         return this;
     }

--- a/src/main/java/org/kohsuke/github/GHDiscussion.java
+++ b/src/main/java/org/kohsuke/github/GHDiscussion.java
@@ -130,7 +130,7 @@ public class GHDiscussion extends GHObject {
      *
      * @return a {@link GHDiscussion.Updater}
      */
-    @Preview
+    @Preview(Previews.SQUIRREL_GIRL)
     @Deprecated
     public GHDiscussion.Updater update() {
         return new GHDiscussion.Updater(this);
@@ -141,7 +141,7 @@ public class GHDiscussion extends GHObject {
      *
      * @return a {@link GHDiscussion.Setter}
      */
-    @Preview
+    @Preview(Previews.SQUIRREL_GIRL)
     @Deprecated
     public GHDiscussion.Setter set() {
         return new GHDiscussion.Setter(this);

--- a/src/main/java/org/kohsuke/github/GHIssue.java
+++ b/src/main/java/org/kohsuke/github/GHIssue.java
@@ -448,7 +448,7 @@ public class GHIssue extends GHObject implements Reactable {
                 .toIterable(GHIssueComment[].class, item -> item.wrapUp(this));
     }
 
-    @Preview
+    @Preview(SQUIRREL_GIRL)
     @Deprecated
     public GHReaction createReaction(ReactionContent content) throws IOException {
         return root.createRequest()
@@ -460,7 +460,7 @@ public class GHIssue extends GHObject implements Reactable {
                 .wrap(root);
     }
 
-    @Preview
+    @Preview(SQUIRREL_GIRL)
     @Deprecated
     public PagedIterable<GHReaction> listReactions() {
         return root.createRequest()

--- a/src/main/java/org/kohsuke/github/GHIssueComment.java
+++ b/src/main/java/org/kohsuke/github/GHIssueComment.java
@@ -126,7 +126,7 @@ public class GHIssueComment extends GHObject implements Reactable {
         owner.root.createRequest().method("DELETE").withUrlPath(getApiRoute()).send();
     }
 
-    @Preview
+    @Preview(SQUIRREL_GIRL)
     @Deprecated
     public GHReaction createReaction(ReactionContent content) throws IOException {
         return owner.root.createRequest()
@@ -138,7 +138,7 @@ public class GHIssueComment extends GHObject implements Reactable {
                 .wrap(owner.root);
     }
 
-    @Preview
+    @Preview(SQUIRREL_GIRL)
     @Deprecated
     public PagedIterable<GHReaction> listReactions() {
         return owner.root.createRequest()

--- a/src/main/java/org/kohsuke/github/GHPullRequest.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequest.java
@@ -576,7 +576,7 @@ public class GHPullRequest extends GHIssue implements Refreshable {
      * @throws IOException
      *             the io exception
      */
-    @Preview
+    @Preview(LYDIAN)
     @Deprecated
     public void updateBranch() throws IOException {
         root.createRequest()

--- a/src/main/java/org/kohsuke/github/GHPullRequestReviewComment.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequestReviewComment.java
@@ -198,7 +198,7 @@ public class GHPullRequestReviewComment extends GHObject implements Reactable {
                 .wrapUp(owner);
     }
 
-    @Preview
+    @Preview(SQUIRREL_GIRL)
     @Deprecated
     public GHReaction createReaction(ReactionContent content) throws IOException {
         return owner.root.createRequest()
@@ -210,7 +210,7 @@ public class GHPullRequestReviewComment extends GHObject implements Reactable {
                 .wrap(owner.root);
     }
 
-    @Preview
+    @Preview(SQUIRREL_GIRL)
     @Deprecated
     public PagedIterable<GHReaction> listReactions() {
         return owner.root.createRequest()

--- a/src/main/java/org/kohsuke/github/GHReaction.java
+++ b/src/main/java/org/kohsuke/github/GHReaction.java
@@ -11,7 +11,7 @@ import static org.kohsuke.github.Previews.*;
  * @author Kohsuke Kawaguchi
  * @see Reactable
  */
-@Preview
+@Preview(SQUIRREL_GIRL)
 @Deprecated
 public class GHReaction extends GHObject {
     private GitHub root;

--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -708,7 +708,7 @@ public class GHRepository extends GHObject {
      * @return the boolean
      */
     @Deprecated
-    @Preview
+    @Preview(BAPTISTE)
     public boolean isTemplate() {
         // isTemplate is still in preview, we do not want to retrieve it unless needed.
         if (isTemplate == null) {
@@ -1925,7 +1925,7 @@ public class GHRepository extends GHObject {
      * @see <a href="https://developer.github.com/v3/checks/runs/#list-check-runs-for-a-specific-ref">List check runs
      *      for a specific ref</a>
      */
-    @Preview
+    @Preview(ANTIOPE)
     @Deprecated
     public PagedIterable<GHCheckRun> getCheckRuns(String ref) throws IOException {
         GitHubRequest request = root.createRequest()
@@ -1999,7 +1999,7 @@ public class GHRepository extends GHObject {
      *            the commit hash
      * @return a builder which you should customize, then call {@link GHCheckRunBuilder#create}
      */
-    @Preview
+    @Preview(ANTIOPE)
     @Deprecated
     public @NonNull GHCheckRunBuilder createCheckRun(@NonNull String name, @NonNull String headSHA) {
         return new GHCheckRunBuilder(this, name, headSHA);
@@ -2012,7 +2012,7 @@ public class GHRepository extends GHObject {
      *            the existing checkId
      * @return a builder which you should customize, then call {@link GHCheckRunBuilder#create}
      */
-    @Preview
+    @Preview(BAPTISTE)
     @Deprecated
     public @NonNull GHCheckRunBuilder updateCheckRun(long checkId) {
         return new GHCheckRunBuilder(this, checkId);
@@ -2959,10 +2959,14 @@ public class GHRepository extends GHObject {
             // There is bug in Push event payloads that returns the wrong url.
             // All other occurrences of "url" take the form "https://api.github.com/...".
             // For Push event repository records, they take the form "https://github.com/{fullName}".
-            root.createRequest().withPreview(BAPTISE).setRawUrlPath(url.toString()).fetchInto(this).wrap(root);
+            root.createRequest().withPreview(BAPTISTE).setRawUrlPath(url.toString()).fetchInto(this).wrap(root);
         } catch (HttpException e) {
             if (e.getCause() instanceof JsonParseException) {
-                root.createRequest().withPreview(BAPTISE).withUrlPath("/repos/" + full_name).fetchInto(this).wrap(root);
+                root.createRequest()
+                        .withPreview(BAPTISTE)
+                        .withUrlPath("/repos/" + full_name)
+                        .fetchInto(this)
+                        .wrap(root);
             } else {
                 throw e;
             }

--- a/src/main/java/org/kohsuke/github/GitHub.java
+++ b/src/main/java/org/kohsuke/github/GitHub.java
@@ -1013,7 +1013,7 @@ public class GitHub {
      * @see <a href="https://developer.github.com/v3/apps/#get-the-authenticated-github-app">Get the authenticated
      *      GitHub App</a>
      */
-    @Preview
+    @Preview(MACHINE_MAN)
     @Deprecated
     public GHApp getApp() throws IOException {
         return createRequest().withPreview(MACHINE_MAN).withUrlPath("/app").fetch(GHApp.class).wrapUp(this);
@@ -1108,7 +1108,7 @@ public class GitHub {
      *
      * @return the gh commit search builder
      */
-    @Preview
+    @Preview(Previews.CLOAK)
     @Deprecated
     public GHCommitSearchBuilder searchCommits() {
         return new GHCommitSearchBuilder(this);

--- a/src/main/java/org/kohsuke/github/GitHubRequest.java
+++ b/src/main/java/org/kohsuke/github/GitHubRequest.java
@@ -437,6 +437,10 @@ class GitHubRequest {
             return withHeader("Accept", name);
         }
 
+        public B withPreview(Previews preview) {
+            return withPreview(preview.mediaType());
+        }
+
         /**
          * With requester.
          *

--- a/src/main/java/org/kohsuke/github/Preview.java
+++ b/src/main/java/org/kohsuke/github/Preview.java
@@ -21,10 +21,10 @@ public @interface Preview {
      * An optional field defining what API media types must be set inorder to support the usage of this annotations
      * target.
      * <p>
-     * This value should be set using the existing constants defined in {@link Previews}
+     * This value must be set using the existing constants defined in {@link Previews}
      *
      * @return The API preview media type.
      */
-    public String[] value() default {};
+    public Previews[] value() default {};
 
 }

--- a/src/main/java/org/kohsuke/github/Previews.java
+++ b/src/main/java/org/kohsuke/github/Previews.java
@@ -7,20 +7,21 @@ package org.kohsuke.github;
  *
  * @author Kohsuke Kawaguchi
  */
-class Previews {
+enum Previews {
+
     /**
      * Check-runs and check-suites
      *
      * @see <a href="https://developer.github.com/v3/previews/#check-runs-and-check-suites-api">GitHub API Previews</a>
      */
-    static final String ANTIOPE = "application/vnd.github.antiope-preview+json";
+    ANTIOPE("application/vnd.github.antiope-preview+json"),
 
     /**
      * Enhanced Deployments
      *
      * @see <a href="https://developer.github.com/v3/previews/#enhanced-deployments">GitHub API Previews</a>
      */
-    static final String ANT_MAN = "application/vnd.github.ant-man-preview+json";
+    ANT_MAN("application/vnd.github.ant-man-preview+json"),
 
     /**
      * Create repository from template repository
@@ -28,28 +29,28 @@ class Previews {
      * @see <a href="https://developer.github.com/v3/previews/#create-and-use-repository-templates">GitHub API
      *      Previews</a>
      */
-    static final String BAPTISE = "application/vnd.github.baptiste-preview+json";
+    BAPTISTE("application/vnd.github.baptiste-preview+json"),
 
     /**
      * Commit Search
      *
      * @see <a href="https://developer.github.com/v3/previews/#commit-search">GitHub API Previews</a>
      */
-    static final String CLOAK = "application/vnd.github.cloak-preview+json";
+    CLOAK("application/vnd.github.cloak-preview+json"),
 
     /**
      * New deployment statuses and support for updating deployment status environment
      *
      * @see <a href="https://developer.github.com/v3/previews/#deployment-statuses">GitHub API Previews</a>
      */
-    static final String FLASH = "application/vnd.github.flash-preview+json";
+    FLASH("application/vnd.github.flash-preview+json"),
 
     /**
      * Owners of GitHub Apps can now uninstall an app using the Apps API
      *
      * @see <a href="https://developer.github.com/v3/previews/#uninstall-a-github-app">GitHub API Previews</a>
      */
-    static final String GAMBIT = "application/vnd.github.gambit-preview+json";
+    GAMBIT("application/vnd.github.gambit-preview+json"),
 
     /**
      * List branches or pull requests for a commit
@@ -57,21 +58,21 @@ class Previews {
      * @see <a href="https://developer.github.com/v3/previews/#list-branches-or-pull-requests-for-a-commit">GitHub API
      *      Previews</a>
      */
-    static final String GROOT = "application/vnd.github.groot-preview+json";
+    GROOT("application/vnd.github.groot-preview+json"),
 
     /**
      * Manage projects
      *
      * @see <a href="https://developer.github.com/v3/previews/#projects">GitHub API Previews</a>
      */
-    static final String INERTIA = "application/vnd.github.inertia-preview+json";
+    INERTIA("application/vnd.github.inertia-preview+json"),
 
     /**
      * Update a pull request branch
      *
      * @see <a href="https://developer.github.com/v3/previews/#update-a-pull-request-branch">GitHub API Previews</a>
      */
-    static final String LYDIAN = "application/vnd.github.lydian-preview+json";
+    LYDIAN("application/vnd.github.lydian-preview+json"),
 
     /**
      * Require multiple approving reviews
@@ -79,21 +80,21 @@ class Previews {
      * @see <a href="https://developer.github.com/v3/previews/#require-multiple-approving-reviews">GitHub API
      *      Previews</a>
      */
-    static final String LUKE_CAGE = "application/vnd.github.luke-cage-preview+json";
+    LUKE_CAGE("application/vnd.github.luke-cage-preview+json"),
 
     /**
      * Manage integrations through the API
      *
      * @see <a href="https://developer.github.com/v3/previews/#integrations">GitHub API Previews</a>
      */
-    static final String MACHINE_MAN = "application/vnd.github.machine-man-preview+json";
+    MACHINE_MAN("application/vnd.github.machine-man-preview+json"),
 
     /**
      * View a list of repository topics in calls that return repository results
      *
      * @see <a href="https://developer.github.com/v3/previews/#repository-topics">GitHub API Previews</a>
      */
-    static final String MERCY = "application/vnd.github.mercy-preview+json";
+    MERCY("application/vnd.github.mercy-preview+json"),
 
     /**
      * New visibility parameter for the Repositories API
@@ -101,27 +102,38 @@ class Previews {
      * @see <a href="https://developer.github.com/v3/previews/#new-visibility-parameter-for-the-repositories-api">GitHub
      *      API Previews</a>
      */
-    static final String NEBULA = "application/vnd.github.nebula-preview+json";
+    NEBULA("application/vnd.github.nebula-preview+json"),
 
     /**
      * Draft pull requests
      *
      * @see <a href="https://developer.github.com/v3/previews/#draft-pull-requests">GitHub API Previews</a>
      */
-    static final String SHADOW_CAT = "application/vnd.github.shadow-cat-preview+json";
+    SHADOW_CAT("application/vnd.github.shadow-cat-preview+json"),
 
     /**
      * Reactions
      *
      * @see <a href="https://developer.github.com/v3/previews/#reactions">GitHub API Previews</a>
      */
-    static final String SQUIRREL_GIRL = "application/vnd.github.squirrel-girl-preview+json";
+    SQUIRREL_GIRL("application/vnd.github.squirrel-girl-preview+json"),
 
     /**
      * Require signed commits
      *
      * @see <a href="https://developer.github.com/v3/previews/#require-signed-commits">GitHub API Previews</a>
      */
-    static final String ZZZAX = "application/vnd.github.zzzax-preview+json";
+    ZZZAX("application/vnd.github.zzzax-preview+json")
 
+    ;
+
+    private final String mediaType;
+
+    Previews(String mediaType) {
+        this.mediaType = mediaType;
+    }
+
+    public String mediaType() {
+        return mediaType;
+    }
 }

--- a/src/main/java/org/kohsuke/github/Reactable.java
+++ b/src/main/java/org/kohsuke/github/Reactable.java
@@ -2,12 +2,14 @@ package org.kohsuke.github;
 
 import java.io.IOException;
 
+import static org.kohsuke.github.Previews.SQUIRREL_GIRL;
+
 /**
  * Those {@link GHObject}s that can have {@linkplain GHReaction reactions}.
  *
  * @author Kohsuke Kawaguchi
  */
-@Preview
+@Preview(SQUIRREL_GIRL)
 @Deprecated
 public interface Reactable {
     /**
@@ -15,7 +17,7 @@ public interface Reactable {
      *
      * @return the paged iterable
      */
-    @Preview
+    @Preview(SQUIRREL_GIRL)
     @Deprecated
     PagedIterable<GHReaction> listReactions();
 
@@ -28,7 +30,7 @@ public interface Reactable {
      * @throws IOException
      *             the io exception
      */
-    @Preview
+    @Preview(SQUIRREL_GIRL)
     @Deprecated
     GHReaction createReaction(ReactionContent content) throws IOException;
 }


### PR DESCRIPTION
# Description 
This PR introduces the following changes:
- Refactor the `Previews` const class into an enum to prevent string constants from being used at `@Preview` use sites.
- Updates existing usages of `@Preview` to include references to `Previews` enum constants.

# Things to consider
- The PR would introduce a breaking change to consumers that rely directly on the older strings constants.
  - They would be able to remediate this by updating their usage from `Previews.ANTMAN` -> `Previews.ANTMAN.mediaType()` 
- One of the main goals of this PR is to improve transparency to consumers on not just which APIs are previews but what previews exactly they depend on. Allowing consumers to make more informed decisions on their usage.
- We are still not requiring a media type to always be included at use sites be it seems like `@Preview` is also being used to denote sdk specific beta APIs in some cases. I suggest, when appropriate we migrate those usages to use a new annotation as to not conflate the two 'Preview' use cases. Something along the lines of `@Hub4jBetaApi` or `@SdkBetaApi`. After that we should have no issue making preview media types a hard requirement.


# Before submitting a PR:
We love getting PRs, but we hate asking people for the same basic changes every time. 

- [X] Push your changes to a branch other than `master`. Create your PR from that branch.    
- [X] Add JavaDocs and other comments
- [X] Write tests that run and pass in CI. See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to capture snapshot data.
- [X] Run `mvn clean compile` locally. This may reformat your code, commit those changes.
- [X] Run `mvn -D enable-ci clean install site` locally. If this command doesn't succeed, your change will not pass CI.

# When creating a PR: 

- [x] Fill in the "Description" above. 
- [x] Enable "Allow edits from maintainers". 
