### PR TITLE
Implement BetaApi annotation for hub4j sdk

### DIFF
--- a/src/main/java/org/kohsuke/github/AbstractBuilder.java
+++ b/src/main/java/org/kohsuke/github/AbstractBuilder.java
@@ -97,7 +97,7 @@ abstract class AbstractBuilder<R, S> {
      *             if there is an I/O Exception
      */
     @Nonnull
-    @Preview
+    @BetaApi
     @Deprecated
     public R done() throws IOException {
         R result;
@@ -127,7 +127,7 @@ abstract class AbstractBuilder<R, S> {
      *             if an I/O error occurs
      */
     @Nonnull
-    @Preview
+    @BetaApi
     @Deprecated
     protected S with(@Nonnull String name, Object value) throws IOException {
         requester.with(name, value);
@@ -148,7 +148,7 @@ abstract class AbstractBuilder<R, S> {
      *             if an I/O error occurs
      */
     @Nonnull
-    @Preview
+    @BetaApi
     @Deprecated
     protected S continueOrDone() throws IOException {
         // This little bit of roughness in this base class means all inheriting builders get to create Updater and

--- a/src/main/java/org/kohsuke/github/BetaApi.java
+++ b/src/main/java/org/kohsuke/github/BetaApi.java
@@ -1,0 +1,18 @@
+package org.kohsuke.github;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Indicates that the method/class/etc marked is a beta implementation of an sdk feature.
+ * <p>
+ * These APIs are subject to change and not a part of the backward compatibility commitment. Always used in conjunction
+ * with 'deprecated' to raise awareness to clients.
+ * </p>
+ *
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface BetaApi {
+}

--- a/src/main/java/org/kohsuke/github/GHAppCreateTokenBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHAppCreateTokenBuilder.java
@@ -19,7 +19,7 @@ public class GHAppCreateTokenBuilder {
     protected final Requester builder;
     private final String apiUrlTail;
 
-    @Preview
+    @BetaApi
     @Deprecated
     GHAppCreateTokenBuilder(GitHub root, String apiUrlTail) {
         this.root = root;
@@ -27,7 +27,7 @@ public class GHAppCreateTokenBuilder {
         this.builder = root.createRequest();
     }
 
-    @Preview
+    @BetaApi
     @Deprecated
     GHAppCreateTokenBuilder(GitHub root, String apiUrlTail, Map<String, GHPermissionType> permissions) {
         this(root, apiUrlTail);
@@ -43,7 +43,7 @@ public class GHAppCreateTokenBuilder {
      *            Array containing the repositories Ids
      * @return a GHAppCreateTokenBuilder
      */
-    @Preview
+    @BetaApi
     @Deprecated
     public GHAppCreateTokenBuilder repositoryIds(List<Long> repositoryIds) {
         this.builder.with("repository_ids", repositoryIds);
@@ -58,7 +58,7 @@ public class GHAppCreateTokenBuilder {
      *            Map containing the permission names and types.
      * @return a GHAppCreateTokenBuilder
      */
-    @Preview
+    @BetaApi
     @Deprecated
     public GHAppCreateTokenBuilder permissions(Map<String, GHPermissionType> permissions) {
         Map<String, String> retMap = new HashMap<>();

--- a/src/main/java/org/kohsuke/github/GHAppInstallation.java
+++ b/src/main/java/org/kohsuke/github/GHAppInstallation.java
@@ -344,7 +344,7 @@ public class GHAppInstallation extends GHObject {
      * @return a GHAppCreateTokenBuilder instance
      * @deprecated Use {@link GHAppInstallation#createToken()} instead.
      */
-    @Preview
+    @BetaApi
     @Deprecated
     public GHAppCreateTokenBuilder createToken(Map<String, GHPermissionType> permissions) {
         return new GHAppCreateTokenBuilder(root,
@@ -361,7 +361,7 @@ public class GHAppInstallation extends GHObject {
      *
      * @return a GHAppCreateTokenBuilder instance
      */
-    @Preview
+    @BetaApi
     @Deprecated
     public GHAppCreateTokenBuilder createToken() {
         return new GHAppCreateTokenBuilder(root, String.format("/app/installations/%d/access_tokens", getId()));

--- a/src/main/java/org/kohsuke/github/GHBranch.java
+++ b/src/main/java/org/kohsuke/github/GHBranch.java
@@ -78,7 +78,7 @@ public class GHBranch {
      *
      * @return true if the push to this branch is restricted via branch protection.
      */
-    @Preview
+    @Preview(Previews.LUKE_CAGE)
     @Deprecated
     public boolean isProtected() {
         return protection;

--- a/src/main/java/org/kohsuke/github/GHCommitComment.java
+++ b/src/main/java/org/kohsuke/github/GHCommitComment.java
@@ -121,7 +121,7 @@ public class GHCommitComment extends GHObject implements Reactable {
         this.body = body;
     }
 
-    @Preview
+    @Preview(SQUIRREL_GIRL)
     @Deprecated
     public GHReaction createReaction(ReactionContent content) throws IOException {
         return owner.root.createRequest()

--- a/src/main/java/org/kohsuke/github/GHLabel.java
+++ b/src/main/java/org/kohsuke/github/GHLabel.java
@@ -132,7 +132,7 @@ public class GHLabel {
      * @throws IOException
      *             the io exception
      */
-    @Preview
+    @BetaApi
     @Deprecated
     static Creator create(GHRepository repository) throws IOException {
         return new Creator(repository);
@@ -179,7 +179,7 @@ public class GHLabel {
      *
      * @return a {@link Updater}
      */
-    @Preview
+    @BetaApi
     @Deprecated
     public Updater update() {
         return new Updater(this);
@@ -190,7 +190,7 @@ public class GHLabel {
      * 
      * @return a {@link Setter}
      */
-    @Preview
+    @BetaApi
     @Deprecated
     public Setter set() {
         return new Setter(this);
@@ -227,7 +227,7 @@ public class GHLabel {
      *
      * {@link #done()} is called automatically after the property is set.
      */
-    @Preview
+    @BetaApi
     @Deprecated
     public static class Setter extends GHLabelBuilder<GHLabel> {
         private Setter(@Nonnull GHLabel base) {
@@ -241,7 +241,7 @@ public class GHLabel {
      *
      * Consumer must call {@link #done()} to commit changes.
      */
-    @Preview
+    @BetaApi
     @Deprecated
     public static class Updater extends GHLabelBuilder<Updater> {
         private Updater(@Nonnull GHLabel base) {
@@ -255,7 +255,7 @@ public class GHLabel {
      *
      * Consumer must call {@link #done()} to create the new instance.
      */
-    @Preview
+    @BetaApi
     @Deprecated
     public static class Creator extends GHLabelBuilder<Creator> {
         private Creator(@Nonnull GHRepository repository) {

--- a/src/main/java/org/kohsuke/github/GHLabelBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHLabelBuilder.java
@@ -38,21 +38,21 @@ class GHLabelBuilder<S> extends AbstractBuilder<GHLabel, S> {
     }
 
     @Nonnull
-    @Preview
+    @BetaApi
     @Deprecated
     public S name(String value) throws IOException {
         return with("name", value);
     }
 
     @Nonnull
-    @Preview
+    @BetaApi
     @Deprecated
     public S color(String value) throws IOException {
         return with("color", value);
     }
 
     @Nonnull
-    @Preview
+    @BetaApi
     @Deprecated
     public S description(String value) throws IOException {
         return with("description", value);

--- a/src/main/java/org/kohsuke/github/GHRelease.java
+++ b/src/main/java/org/kohsuke/github/GHRelease.java
@@ -260,7 +260,6 @@ public class GHRelease extends GHObject {
      *             existing logic in place for backwards compatibility.
      */
     @Deprecated
-    @Preview
     public List<GHAsset> assets() {
         return assets;
     }

--- a/src/main/java/org/kohsuke/github/GHRepositoryStatistics.java
+++ b/src/main/java/org/kohsuke/github/GHRepositoryStatistics.java
@@ -60,7 +60,7 @@ public class GHRepositoryStatistics {
      * @throws InterruptedException
      *             the interrupted exception
      */
-    @Preview
+    @BetaApi
     @Deprecated
     @SuppressWarnings("SleepWhileInLoop")
     @SuppressFBWarnings(value = { "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE" }, justification = "JSON API")

--- a/src/main/java/org/kohsuke/github/GitUser.java
+++ b/src/main/java/org/kohsuke/github/GitUser.java
@@ -42,8 +42,6 @@ public class GitUser {
      *
      * @return GitHub username
      */
-    @Preview
-    @Deprecated
     @CheckForNull
     public String getUsername() {
         return username;

--- a/src/main/java/org/kohsuke/github/Preview.java
+++ b/src/main/java/org/kohsuke/github/Preview.java
@@ -25,6 +25,6 @@ public @interface Preview {
      *
      * @return The API preview media type.
      */
-    public Previews[] value() default {};
+    public Previews[] value();
 
 }

--- a/src/test/java/org/kohsuke/github/ArchTests.java
+++ b/src/test/java/org/kohsuke/github/ArchTests.java
@@ -1,5 +1,7 @@
 package org.kohsuke.github;
 
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaAnnotation;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.core.importer.ImportOption;
@@ -7,6 +9,8 @@ import com.tngtech.archunit.lang.ArchRule;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import static com.tngtech.archunit.lang.conditions.ArchConditions.beAnnotatedWith;
+import static com.tngtech.archunit.lang.conditions.ArchConditions.not;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
@@ -18,6 +22,17 @@ public class ArchTests {
             .withImportOption(new ImportOption.DoNotIncludeTests())
             .withImportOption(new ImportOption.DoNotIncludeJars())
             .importPackages("org.kohsuke.github");
+
+    private static final DescribedPredicate<JavaAnnotation<?>> previewAnnotationWithNoMediaType = new DescribedPredicate<JavaAnnotation<?>>(
+            "preview has no required media types defined") {
+
+        @Override
+        public boolean apply(JavaAnnotation<?> javaAnnotation) {
+            boolean isPreview = javaAnnotation.getRawType().isEquivalentTo(Preview.class);
+            Object[] values = (Object[]) javaAnnotation.getProperties().get("value");
+            return isPreview && values != null && values.length < 1;
+        }
+    };
 
     @BeforeClass
     public static void beforeClass() {
@@ -33,10 +48,45 @@ public class ArchTests {
                 .areAnnotatedWith(Preview.class)
                 .should()
                 .beAnnotatedWith(Deprecated.class)
+                .andShould(not(beAnnotatedWith(previewAnnotationWithNoMediaType)))
                 .because(reason);
 
         ArchRule methodRule = methods().that()
                 .areAnnotatedWith(Preview.class)
+                .should()
+                .beAnnotatedWith(Deprecated.class)
+                .andShould(not(beAnnotatedWith(previewAnnotationWithNoMediaType)))
+                .because(reason);
+
+        ArchRule enumFieldsRule = fields().that()
+                .areDeclaredInClassesThat()
+                .areEnums()
+                .and()
+                .areAnnotatedWith(Preview.class)
+                .should()
+                .beAnnotatedWith(Deprecated.class)
+                .andShould(not(beAnnotatedWith(previewAnnotationWithNoMediaType)))
+                .because(reason);
+
+        classRule.check(classFiles);
+        enumFieldsRule.check(classFiles);
+        methodRule.check(classFiles);
+
+    }
+
+    @Test
+    public void testBetaApisAreFlaggedAsDeprecated() {
+
+        String reason = "all beta APIs must be annotated as @Deprecated until they are promoted to stable";
+
+        ArchRule classRule = classes().that()
+                .areAnnotatedWith(BetaApi.class)
+                .should()
+                .beAnnotatedWith(Deprecated.class)
+                .because(reason);
+
+        ArchRule methodRule = methods().that()
+                .areAnnotatedWith(BetaApi.class)
                 .should()
                 .beAnnotatedWith(Deprecated.class)
                 .because(reason);
@@ -45,7 +95,7 @@ public class ArchTests {
                 .areDeclaredInClassesThat()
                 .areEnums()
                 .and()
-                .areAnnotatedWith(Preview.class)
+                .areAnnotatedWith(BetaApi.class)
                 .should()
                 .beAnnotatedWith(Deprecated.class)
                 .because(reason);


### PR DESCRIPTION
# Description 
This PR introduces a `@BetaApi` annotation to help differentiate Github `@Preview` APIs from hub4j beta APIs. The reasoning behind this change is based on the findings outlined in https://github.com/hub4j/github-api/pull/1001. With these changes, the preview media type is now a hard requirement. Architecture tests have been added to ensure beta APIs are annotated as deprecated and that usages of preview do not allow empty arrays.

# Before submitting a PR:
We love getting PRs, but we hate asking people for the same basic changes every time. 

- [X] Push your changes to a branch other than `master`. Create your PR from that branch.    
- [X] Add JavaDocs and other comments
- [X] Write tests that run and pass in CI. See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to capture snapshot data.
- [X] Run `mvn clean compile` locally. This may reformat your code, commit those changes.
- [X] Run `mvn -D enable-ci clean install site` locally. If this command doesn't succeed, your change will not pass CI.

# When creating a PR: 

- [X] Fill in the "Description" above. 
- [X] Enable "Allow edits from maintainers". 
