### PR TITLE
Add timestamp field support for the commits sent by GHEventPayload.Push

### DIFF
--- a/src/main/java/org/kohsuke/github/GHEventPayload.java
+++ b/src/main/java/org/kohsuke/github/GHEventPayload.java
@@ -1160,6 +1160,7 @@ public class GHEventPayload extends GitHubInteractiveObject {
 
             /**
              * Obtains the timestamp of the commit
+             *
              * @return the timestamp
              */
             public Date getTimestamp() {

--- a/src/main/java/org/kohsuke/github/GHEventPayload.java
+++ b/src/main/java/org/kohsuke/github/GHEventPayload.java
@@ -5,6 +5,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.util.Date;
 import java.util.List;
 
 /**
@@ -1067,7 +1068,7 @@ public class GHEventPayload extends GitHubInteractiveObject {
         public static class PushCommit {
             private GitUser author;
             private GitUser committer;
-            private String url, sha, message;
+            private String url, sha, message, timestamp;
             private boolean distinct;
             private List<String> added, removed, modified;
 
@@ -1155,6 +1156,14 @@ public class GHEventPayload extends GitHubInteractiveObject {
              */
             public List<String> getModified() {
                 return modified;
+            }
+
+            /**
+             * Obtains the timestamp of the commit
+             * @return the timestamp
+             */
+            public Date getTimestamp() {
+                return GitHubClient.parseDate(timestamp);
             }
         }
     }

--- a/src/test/java/org/kohsuke/github/GHEventPayloadTest.java
+++ b/src/test/java/org/kohsuke/github/GHEventPayloadTest.java
@@ -361,6 +361,9 @@ public class GHEventPayloadTest extends AbstractGitHubWireMockTest {
         assertThat(event.getCommits().get(0).getRemoved().size(), is(0));
         assertThat(event.getCommits().get(0).getModified().size(), is(1));
         assertThat(event.getCommits().get(0).getModified().get(0), is("README.md"));
+        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        formatter.setTimeZone(TimeZone.getTimeZone("UTC"));
+        assertThat(formatter.format(event.getCommits().get(0).getTimestamp()), is("2015-05-05T23:40:15Z"));
         assertThat(event.getRepository().getName(), is("public-repo"));
         assertThat(event.getRepository().getOwnerName(), is("baxterthehacker"));
         assertThat(event.getRepository().getUrl().toExternalForm(),


### PR DESCRIPTION
# Description 
This Pull Request adds support for parsing the timestamp field in the GHEventPayload.Push.PushCommit class

# Before submitting a PR:
We love getting PRs, but we hate asking people for the same basic changes every time. 

- [X] Push your changes to a branch other than `master`. Create your PR from that branch.    
- [X] Add JavaDocs and other comments
- [X] Write tests that run and pass in CI. See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to capture snapshot data.
- [X] Run `mvn clean compile` locally. This may reformat your code, commit those changes.
- [X] Run `mvn -D enable-ci clean install site` locally. If this command doesn't succeed, your change will not pass CI.

# When creating a PR: 

- [X] Fill in the "Description" above. 
- [X] Enable "Allow edits from maintainers". 
