### PR TITLE
Allow for time skew in JWT authentication

### DIFF
--- a/src/main/java/org/kohsuke/github/extras/authorization/JWTTokenProvider.java
+++ b/src/main/java/org/kohsuke/github/extras/authorization/JWTTokenProvider.java
@@ -103,20 +103,28 @@ public class JWTTokenProvider implements AuthorizationProvider {
     private String refreshJWT() {
         Instant now = Instant.now();
 
-        // Token expires in 10 minutes
-        Instant expiration = Instant.now().plus(Duration.ofMinutes(10));
+        // Max token expiration is 10 minutes for GitHub
+        // We use a smaller window since we likely will not need more than a few seconds
+        Instant expiration = now.plus(Duration.ofMinutes(8));
+
+        // Setting the issued at to a time in the past to allow for clock skew
+        Instant issuedAt = getIssuedAt(now);
 
         // Let's set the JWT Claims
         JwtBuilder builder = Jwts.builder()
-                .setIssuedAt(Date.from(now))
+                .setIssuedAt(Date.from(issuedAt))
                 .setExpiration(Date.from(expiration))
                 .setIssuer(this.applicationId)
                 .signWith(privateKey, SignatureAlgorithm.RS256);
 
-        // Token will refresh after 8 minutes
+        // Token will refresh 2 minutes before it expires
         validUntil = expiration.minus(Duration.ofMinutes(2));
 
         // Builds the JWT and serializes it to a compact, URL-safe string
         return builder.compact();
+    }
+
+    Instant getIssuedAt(Instant now) {
+        return now.minus(Duration.ofMinutes(2));
     }
 }

--- a/src/test/resources/org/kohsuke/github/extras/authorization/JWTTokenProviderTest/wiremock/testIssuedAtSkew/mappings/app-2.json
+++ b/src/test/resources/org/kohsuke/github/extras/authorization/JWTTokenProviderTest/wiremock/testIssuedAtSkew/mappings/app-2.json
@@ -1,0 +1,37 @@
+{
+  "id": "70456278-27d2-470a-bdfb-0edb4ac61781",
+  "name": "app",
+  "request": {
+    "url": "/app",
+    "method": "GET",
+    "headers": {
+      "Authorization": {
+        "matches": "^Bearer (?<JWTHeader>ey\\S*)\\.(?<JWTPayload>\\S*)\\.(?<JWTSignature>\\S*)$"
+      },
+      "Accept": {
+        "equalTo": "application/vnd.github.machine-man-preview+json"
+      }
+    }
+  },
+  "response": {
+    "status": 401,
+    "body": "{\"message\":\"'Issued at' claim ('iat') must be an Integer representing the time that the assertion was issued\",\"documentation_url\":\"https://docs.github.com/rest\"}",
+    "headers": {
+      "Server": "GitHub.com",
+      "Date": "Thu, 25 Feb 2021 18:29:11 GMT",
+      "Content-Type": "application/json; charset=utf-8",
+      "X-GitHub-Media-Type": "github.v3; param=machine-man-preview; format=json",
+      "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",
+      "X-Frame-Options": "deny",
+      "X-Content-Type-Options": "nosniff",
+      "X-XSS-Protection": "1; mode=block",
+      "Referrer-Policy": "origin-when-cross-origin, strict-origin-when-cross-origin",
+      "Content-Security-Policy": "default-src 'none'",
+      "Vary": "Accept-Encoding, Accept, X-Requested-With",
+      "X-GitHub-Request-Id": "F443:2D43:8AECD5:A2A02D:6037EC76"
+    }
+  },
+  "uuid": "70456278-27d2-470a-bdfb-0edb4ac61781",
+  "persistent": true,
+  "insertionIndex": 2
+}


### PR DESCRIPTION
# Description 
The examples provided in GitHub docs do not explain this, but it makes sense to set the `issuedAt` field to slightly in the past to allow for minor clock drift between the client system and the server.  This change sets `issuedAt` to two minutes in the past and expiration two minutes earlier as well. This means that the client can be up to two minutes ahead of the server and the JWT will still work.  The token will still autorefresh two minutes before it is set to expire (a total of four minutes earlier).  This means tokens will expire at 6 minutes, however they are rarely used for more than a minute to get new GitHub App Installation tokens. 

While this still doesn't fix JENKINS-62249 it is an easy fix for one more source of access denied errors and has no downside that I can see. 

# Before submitting a PR:
We love getting PRs, but we hate asking people for the same basic changes every time. 

- [x] Push your changes to a branch other than `master`. Create your PR from that branch.    
- [x] Add JavaDocs and other comments
- [x] Write tests that run and pass in CI. See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to capture snapshot data.
- [x] Run `mvn clean compile` locally. This may reformat your code, commit those changes.
- [x] Run `mvn -D enable-ci clean install site` locally. If this command doesn't succeed, your change will not pass CI.

# When creating a PR: 

- [x] Fill in the "Description" above. 
- [x] Enable "Allow edits from maintainers". 
