### PR TITLE
Test that void bridge methods are created

### DIFF
--- a/src/test/java/org/kohsuke/github/BridgeMethodTest.java
+++ b/src/test/java/org/kohsuke/github/BridgeMethodTest.java
@@ -33,6 +33,7 @@ public class BridgeMethodTest extends Assert {
         verifyBridgeMethods(GHIssue.class, "getCreatedAt", Date.class, String.class);
         verifyBridgeMethods(GHIssue.class, "getId", int.class, long.class, String.class);
         verifyBridgeMethods(GHIssue.class, "getUrl", String.class, URL.class);
+        verifyBridgeMethods(GHIssue.class, "comment", 1, void.class, GHIssueComment.class);
 
         verifyBridgeMethods(GHOrganization.class, "getHtmlUrl", String.class, URL.class);
         verifyBridgeMethods(GHOrganization.class, "getId", int.class, long.class, String.class);
@@ -55,12 +56,17 @@ public class BridgeMethodTest extends Assert {
     }
 
     void verifyBridgeMethods(@Nonnull Class<?> targetClass, @Nonnull String methodName, Class<?>... returnTypes) {
+        verifyBridgeMethods(targetClass, methodName, 0, returnTypes);
+    }
+
+    void verifyBridgeMethods(@Nonnull Class<?> targetClass,
+            @Nonnull String methodName,
+            int parameterCount,
+            Class<?>... returnTypes) {
         List<Class<?>> foundMethods = new ArrayList<>();
         Method[] methods = targetClass.getMethods();
         for (Method method : methods) {
-            if (method.getName().equalsIgnoreCase(methodName)) {
-                // Bridge methods are only
-                assertThat(method.getParameterCount(), equalTo(0));
+            if (method.getName().equalsIgnoreCase(methodName) && method.getParameterCount() == parameterCount) {
                 foundMethods.add(method.getReturnType());
             }
         }


### PR DESCRIPTION
# Description 
Looking at whether #1050 would be easy or hard to fix.  Turns out there is already a method that has a `void` bridge method.  

https://github.com/hub4j/github-api/blob/6d86cfb4f60642ccfc3ad943eeb472e33e2ff9ec/src/main/java/org/kohsuke/github/GHIssue.java#L217-L218

This change adds a test showing that the correct bridge method is created. 

As part of this I also manually verified that the `void` bridge method works. 
