### PR TITLE
Add the missing fields for GHLabel

### DIFF
--- a/src/main/java/org/kohsuke/github/GHLabel.java
+++ b/src/main/java/org/kohsuke/github/GHLabel.java
@@ -2,6 +2,7 @@ package org.kohsuke.github;
 
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -22,6 +23,11 @@ import javax.annotation.Nonnull;
  */
 public class GHLabel extends GitHubInteractiveObject {
 
+    private long id;
+    private String nodeId;
+    @JsonProperty("default")
+    private boolean default_;
+
     @Nonnull
     private String url, name, color;
 
@@ -40,6 +46,24 @@ public class GHLabel extends GitHubInteractiveObject {
     @Nonnull
     GitHub getApiRoot() {
         return Objects.requireNonNull(root);
+    }
+
+    /**
+     * Gets id.
+     *
+     * @return the id
+     */
+    public long getId() {
+        return id;
+    }
+
+    /**
+     * Gets node id.
+     *
+     * @return the node id.
+     */
+    public String getNodeId() {
+        return nodeId;
     }
 
     /**
@@ -80,6 +104,15 @@ public class GHLabel extends GitHubInteractiveObject {
     @CheckForNull
     public String getDescription() {
         return description;
+    }
+
+    /**
+     * If the label is one of the default labels created by GitHub automatically.
+     *
+     * @return true if the label is a default one
+     */
+    public boolean isDefault() {
+        return default_;
     }
 
     /**

--- a/src/test/java/org/kohsuke/github/AppTest.java
+++ b/src/test/java/org/kohsuke/github/AppTest.java
@@ -965,6 +965,9 @@ public class AppTest extends AbstractGitHubWireMockTest {
         GHLabel e = r.getLabel("enhancement");
         assertEquals("enhancement", e.getName());
         assertNotNull(e.getUrl());
+        assertEquals(177339106, e.getId());
+        assertEquals("MDU6TGFiZWwxNzczMzkxMDY=", e.getNodeId());
+        assertTrue(e.isDefault());
         assertTrue(Pattern.matches("[0-9a-fA-F]{6}", e.getColor()));
 
         GHLabel t = null;
@@ -976,12 +979,17 @@ public class AppTest extends AbstractGitHubWireMockTest {
             assertThat(t, not(sameInstance(t2)));
             assertThat(t, equalTo(t2));
 
+            assertFalse(t2.isDefault());
+
+            assertEquals(t.getId(), t2.getId());
+            assertEquals(t.getNodeId(), t2.getNodeId());
             assertEquals(t.getName(), t2.getName());
             assertEquals(t.getColor(), "123456");
             assertEquals(t.getColor(), t2.getColor());
             assertEquals(t.getDescription(), "");
             assertEquals(t.getDescription(), t2.getDescription());
             assertEquals(t.getUrl(), t2.getUrl());
+            assertEquals(t.isDefault(), t2.isDefault());
 
             // update works on multiple changes in one call
             t3 = t.update().color("000000").description("It is dark!").done();

--- a/src/test/java/org/kohsuke/github/GHPullRequestTest.java
+++ b/src/test/java/org/kohsuke/github/GHPullRequestTest.java
@@ -9,7 +9,14 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -418,7 +425,11 @@ public class GHPullRequestTest extends AbstractGitHubWireMockTest {
 
         Collection<GHLabel> labels = getRepository().getPullRequest(p.getNumber()).getLabels();
         assertEquals(1, labels.size());
-        assertEquals(label, labels.iterator().next().getName());
+        GHLabel savedLabel = labels.iterator().next();
+        assertEquals(label, savedLabel.getName());
+        assertNotNull(savedLabel.getId());
+        assertNotNull(savedLabel.getNodeId());
+        assertFalse(savedLabel.isDefault());
     }
 
     @Test


### PR DESCRIPTION
# Description 

Add the missing fields for GHLabel (id, nodeId, default).

Fixes #1059

# Before submitting a PR:
We love getting PRs, but we hate asking people for the same basic changes every time. 

- [X] Push your changes to a branch other than `master`. Create your PR from that branch.    
- [X] Add JavaDocs and other comments
- [X] Write tests that run and pass in CI. See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to capture snapshot data.
- [X] Run `mvn -D enable-ci clean install site` locally. If this command doesn't succeed, your change will not pass CI. 

# When creating a PR: 

- [X] Fill in the "Description" above. 
- [X] Enable "Allow edits from maintainers". 
