### PR TITLE
Make Jacoco work on java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
             <!-- attached to Maven test phase -->
             <execution>
               <id>report</id>
-              <phase>test</phase>
+              <phase>package</phase>
               <goals>
                 <goal>report</goal>
               </goals>
@@ -591,9 +591,9 @@
       </build>
     </profile>
     <profile>
-      <id>jdk11+</id>
+      <id>jdk11plus</id>
       <activation>
-        <jdk>[11,)</jdk>
+        <jdk>[13,)</jdk>
       </activation>
       <properties>
         <!-- this is required for GithubHttpUrlConnectionClient#setRequestMethod() to work with JDK 16+ -->

--- a/pom.xml
+++ b/pom.xml
@@ -642,6 +642,30 @@
               </execution>
             </executions>
           </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <version>3.0.0-M3</version>
+            <executions>
+              <execution>
+                <id>enforce-jacoco-exist</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>enforce</goal>
+                </goals>
+                <configuration>
+                  <rules>
+                    <requireFilesExist>
+                      <files>
+                        <file>${project.build.outputDirectory}/jacoco.exec</file>
+                      </files>
+                    </requireFilesExist>
+                  </rules>
+                  <fail>true</fail>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
         </plugins>
       </build>
     </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -657,7 +657,7 @@
                   <rules>
                     <requireFilesExist>
                       <files>
-                        <file>${project.build.outputDirectory}/jacoco.exec</file>
+                        <file>${project.build.directory}/jacoco.exec</file>
                       </files>
                     </requireFilesExist>
                   </rules>

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,9 @@
           <configuration>
             <!-- SUREFIRE-1226 workaround -->
             <trimStackTrace>false</trimStackTrace>
+            <systemPropertyVariables>
+              <jacoco-agent.destfile>target/jacoco.exec</jacoco-agent.destfile>
+            </systemPropertyVariables>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
# Description 
It appears that the change to unblock jacoco on Java 16+ broke jacoco on Java 11.   I noticed this because running `mvn -Denable-ci install site" on Java 11 does not produce the jacoco report in the `target/site` folder.  Java 8 works., but I want to use Java 11 for releases, including site generation.  

@gsmet  Any thoughts on this? 

