### PR TITLE
Properly wrap the check runs with the repository when listing them

### DIFF
--- a/src/main/java/org/kohsuke/github/GHCheckRunsIterable.java
+++ b/src/main/java/org/kohsuke/github/GHCheckRunsIterable.java
@@ -8,13 +8,13 @@ import javax.annotation.Nonnull;
  * Iterable for check-runs listing.
  */
 class GHCheckRunsIterable extends PagedIterable<GHCheckRun> {
-    private final transient GitHub root;
+    private final GHRepository owner;
     private final GitHubRequest request;
 
     private GHCheckRunsPage result;
 
-    public GHCheckRunsIterable(GitHub root, GitHubRequest request) {
-        this.root = root;
+    public GHCheckRunsIterable(GHRepository owner, GitHubRequest request) {
+        this.owner = owner;
         this.request = request;
     }
 
@@ -22,7 +22,7 @@ class GHCheckRunsIterable extends PagedIterable<GHCheckRun> {
     @Override
     public PagedIterator<GHCheckRun> _iterator(int pageSize) {
         return new PagedIterator<>(
-                adapt(GitHubPageIterator.create(root.getClient(), GHCheckRunsPage.class, request, pageSize)),
+                adapt(GitHubPageIterator.create(owner.getRoot().getClient(), GHCheckRunsPage.class, request, pageSize)),
                 null);
     }
 
@@ -37,7 +37,7 @@ class GHCheckRunsIterable extends PagedIterable<GHCheckRun> {
                 if (result == null) {
                     result = v;
                 }
-                return v.getCheckRuns(root);
+                return v.getCheckRuns(owner);
             }
         };
     }

--- a/src/main/java/org/kohsuke/github/GHCheckRunsPage.java
+++ b/src/main/java/org/kohsuke/github/GHCheckRunsPage.java
@@ -11,9 +11,9 @@ class GHCheckRunsPage {
         return total_count;
     }
 
-    GHCheckRun[] getCheckRuns(GitHub root) {
+    GHCheckRun[] getCheckRuns(GHRepository owner) {
         for (GHCheckRun check_run : check_runs) {
-            check_run.wrap(root);
+            check_run.wrap(owner);
         }
         return check_runs;
     }

--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -2010,7 +2010,7 @@ public class GHRepository extends GHObject {
                 .withUrlPath(String.format("/repos/%s/%s/commits/%s/check-runs", getOwnerName(), name, ref))
                 .withPreview(ANTIOPE)
                 .build();
-        return new GHCheckRunsIterable(root, request);
+        return new GHCheckRunsIterable(this, request);
     }
 
     /**

--- a/src/test/java/org/kohsuke/github/GHRepositoryTest.java
+++ b/src/test/java/org/kohsuke/github/GHRepositoryTest.java
@@ -773,6 +773,11 @@ public class GHRepositoryTest extends AbstractGitHubWireMockTest {
             checkRunsCount++;
         }
         assertThat(checkRunsCount, equalTo(expectedCount));
+
+        // Check that we can call update on the results
+        for (GHCheckRun checkRun : checkRuns) {
+            checkRun.update();
+        }
     }
 
     @Test


### PR DESCRIPTION
Otherwise you have a not so nice NPE when trying to update them:
```
java.lang.NullPointerException
	at org.kohsuke.github.GHCheckRunBuilder.<init>(GHCheckRunBuilder.java:75)
	at org.kohsuke.github.GHCheckRun.update(GHCheckRun.java:339)
```

I added a basic test to check we are able to call the builder as that's the only problem I can foresee there.