### PR TITLE
Log 202 message at the FINE level

### DIFF
--- a/src/main/java/org/kohsuke/github/GitHubClient.java
+++ b/src/main/java/org/kohsuke/github/GitHubClient.java
@@ -438,15 +438,15 @@ abstract class GitHubClient {
             // special case handling for 304 unmodified, as the content will be ""
         } else if (responseInfo.statusCode() == HttpURLConnection.HTTP_ACCEPTED) {
 
-            // Response code 202 means data is being generated.
+            // Response code 202 means data is being generated or an action that can require some time is triggered.
             // This happens in specific cases:
             // statistics - See https://developer.github.com/v3/repos/statistics/#a-word-about-caching
             // fork creation - See https://developer.github.com/v3/repos/forks/#create-a-fork
+            // workflow run cancellation - See https://docs.github.com/en/rest/reference/actions#cancel-a-workflow-run
 
-            LOGGER.log(INFO,
+            LOGGER.log(FINE,
                     "Received HTTP_ACCEPTED(202) from " + responseInfo.url().toString()
                             + " . Please try again in 5 seconds.");
-            // Maybe throw an exception instead?
         } else if (handler != null) {
             body = handler.apply(responseInfo);
         }


### PR DESCRIPTION
Also reintroduce the special case we had before as the info is
important.

@bitwiseman you removed the special cases to improve code coverage but I don't think it's a good idea.

For me, either we keep the logs and make them informative or we remove the log altogether given 202 is a success. It's just that the operation takes time.

In the case of cancel, I dropped the log as really you just want to cancel the thing, you don't really care that it will take time.