### PR TITLE
upgrade commons-io due to CVE-2021-29425

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -429,7 +429,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.4</version>
+      <version>2.8.0</version>
     </dependency>
     <dependency>
       <groupId>com.infradna.tool</groupId>

--- a/src/test/java/org/kohsuke/github/ArchTests.java
+++ b/src/test/java/org/kohsuke/github/ArchTests.java
@@ -153,7 +153,7 @@ public class ArchTests {
     @Test
     public void testRequireUseOfOnlySpecificApacheCommons() {
 
-        final ArchRule onlyApprovedApacheCommonsLang3Methods = classes()
+        final ArchRule onlyApprovedApacheCommonsMethods = classes()
                 .should(notCallMethodsInPackageUnless("org.apache.commons..",
                         // unless it is one of these methods
                         targetMethodIs(StringUtils.class, "capitalize", String.class),
@@ -187,9 +187,9 @@ public class ArchTests {
                         targetMethodIs(IOUtils.class, "toString", Reader.class),
                         targetMethodIs(IOUtils.class, "toByteArray", InputStream.class)))
                 .because(
-                        "Commons methods must be manually verified to be compatible with commons-io:2.4 or earlier and commons-lang3:3.9 or earlier should be used.");
+                        "Commons methods must be manually verified to be compatible with commons-io:2.4 or earlier and commons-lang3:3.9 or earlier.");
 
-        onlyApprovedApacheCommonsLang3Methods.check(classFiles);
+        onlyApprovedApacheCommonsMethods.check(classFiles);
     }
 
     public static ArchCondition<JavaClass> notCallMethodsInPackageUnless(final String packageIdentifier,

--- a/src/test/java/org/kohsuke/github/ArchTests.java
+++ b/src/test/java/org/kohsuke/github/ArchTests.java
@@ -175,7 +175,7 @@ public class ArchTests {
                         target(HasOwner.Predicates.With.<JavaClass>owner(resideInAPackage("org.apache.commons..")))
                                 .and(DescribedPredicate.not(approvedApacheCommonsMethods)))))
                 .because(
-                        "Only commons methods that have been manually verified to be compatible with v2.4 should be used.");
+                        "Only commons methods that have been manually verified to be compatible with commons-io:2.4 or earlier and commons-lang3:3.9 or earlier should be used.");
 
         onlyApprovedApacheCommonsLang3Methods.check(classFiles);
     }

--- a/src/test/java/org/kohsuke/github/ArchTests.java
+++ b/src/test/java/org/kohsuke/github/ArchTests.java
@@ -169,7 +169,7 @@ public class ArchTests {
                 .or(approvedToStringStyleMethods)
                 .or(approvedReflectionStringBuilderMethods)
                 .or(approvedIOUtilsMethods);
-        
+
         final ArchRule onlyApprovedApacheCommonsLang3Methods = classes()
                 .should(not(callMethodWhere(
                         target(HasOwner.Predicates.With.<JavaClass>owner(resideInAPackage("org.apache.commons..")))

--- a/src/test/java/org/kohsuke/github/GHPullRequestMockTest.java
+++ b/src/test/java/org/kohsuke/github/GHPullRequestMockTest.java
@@ -4,7 +4,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -15,7 +15,7 @@ public class GHPullRequestMockTest {
         GHPullRequest pullRequest = mock(GHPullRequest.class);
         when(pullRequest.isDraft()).thenReturn(true);
 
-        assertTrue("Mock should return true", pullRequest.isDraft());
+        assertThat("Mock should return true", pullRequest.isDraft());
     }
 
 }

--- a/src/test/java/org/kohsuke/github/internal/EnumUtilsTest.java
+++ b/src/test/java/org/kohsuke/github/internal/EnumUtilsTest.java
@@ -2,19 +2,24 @@ package org.kohsuke.github.internal;
 
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
 
 public class EnumUtilsTest {
 
     @Test
     public void testGetEnum() {
-        assertNull(EnumUtils.getNullableEnumOrDefault(TestEnum.class, null, TestEnum.UNKNOWN));
-        assertEquals(TestEnum.UNKNOWN, EnumUtils.getNullableEnumOrDefault(TestEnum.class, "foobar", TestEnum.UNKNOWN));
-        assertEquals(TestEnum.VALUE_1, EnumUtils.getNullableEnumOrDefault(TestEnum.class, "VALUE_1", TestEnum.UNKNOWN));
-        assertEquals(TestEnum.VALUE_1, EnumUtils.getNullableEnumOrDefault(TestEnum.class, "value_1", TestEnum.UNKNOWN));
-        assertEquals(TestEnum.VALUE_2, EnumUtils.getNullableEnumOrDefault(TestEnum.class, "VALUE_2", TestEnum.UNKNOWN));
-        assertEquals(TestEnum.VALUE_2, EnumUtils.getNullableEnumOrDefault(TestEnum.class, "value_2", TestEnum.UNKNOWN));
+        assertThat(EnumUtils.getNullableEnumOrDefault(TestEnum.class, null, TestEnum.UNKNOWN), nullValue());
+        assertThat(EnumUtils.getNullableEnumOrDefault(TestEnum.class, "foobar", TestEnum.UNKNOWN),
+                equalTo(TestEnum.UNKNOWN));
+        assertThat(EnumUtils.getNullableEnumOrDefault(TestEnum.class, "VALUE_1", TestEnum.UNKNOWN),
+                equalTo(TestEnum.VALUE_1));
+        assertThat(EnumUtils.getNullableEnumOrDefault(TestEnum.class, "value_1", TestEnum.UNKNOWN),
+                equalTo(TestEnum.VALUE_1));
+        assertThat(EnumUtils.getNullableEnumOrDefault(TestEnum.class, "VALUE_2", TestEnum.UNKNOWN),
+                equalTo(TestEnum.VALUE_2));
+        assertThat(EnumUtils.getNullableEnumOrDefault(TestEnum.class, "vAlUe_2 ", TestEnum.UNKNOWN),
+                equalTo(TestEnum.VALUE_2));
     }
 
     private enum TestEnum {

--- a/src/test/java/org/kohsuke/github/internal/EnumUtilsTest.java
+++ b/src/test/java/org/kohsuke/github/internal/EnumUtilsTest.java
@@ -18,7 +18,7 @@ public class EnumUtilsTest {
                 equalTo(TestEnum.VALUE_1));
         assertThat(EnumUtils.getNullableEnumOrDefault(TestEnum.class, "VALUE_2", TestEnum.UNKNOWN),
                 equalTo(TestEnum.VALUE_2));
-        assertThat(EnumUtils.getNullableEnumOrDefault(TestEnum.class, "vAlUe_2 ", TestEnum.UNKNOWN),
+        assertThat(EnumUtils.getNullableEnumOrDefault(TestEnum.class, "vAlUe_2", TestEnum.UNKNOWN),
                 equalTo(TestEnum.VALUE_2));
     }
 


### PR DESCRIPTION
# Description

Upgrade commons-io to 2.8.0, it's a vulnerability in FileNameUtils.normalize that isn't used in this project.

More information about the vulnerability can be found here: https://issues.apache.org/jira/browse/IO-556

I have run the tests locally (which failed to to unrelated javadoc warnings) and done a basic check in my application that uses github-api, but not done any other testing. 