### PR TITLE
(refactor) Replace complex parsing logic from GHEvent.type to GHEvent with static mapping

### DIFF
--- a/src/main/java/org/kohsuke/github/GHEvent.java
+++ b/src/main/java/org/kohsuke/github/GHEvent.java
@@ -2,6 +2,8 @@ package org.kohsuke.github;
 
 import java.util.Locale;
 
+import javax.annotation.Nonnull;
+
 /**
  * Hook event type.
  *
@@ -84,5 +86,51 @@ public enum GHEvent {
         if (this == ALL)
             return "*";
         return name().toLowerCase(Locale.ENGLISH);
+    }
+
+    /**
+     * Representation of GitHub Event Type
+     *
+     * @see <a href="https://docs.github.com/en/developers/webhooks-and-events/github-event-types">GitHub event
+     *      types</a>
+     */
+    public enum GitHubEventType {
+        CommitCommentEvent(COMMIT_COMMENT),
+        CreateEvent(CREATE),
+        DeleteEvent(DELETE),
+        ForkEvent(FORK),
+        GollumEvent(GOLLUM),
+        IssueCommentEvent(ISSUE_COMMENT),
+        IssuesEvent(ISSUES),
+        MemberEvent(MEMBER),
+        PublicEvent(PUBLIC),
+        PullRequestEvent(PULL_REQUEST),
+        PullRequestReviewEvent(PULL_REQUEST_REVIEW),
+        PullRequestReviewCommentEvent(PULL_REQUEST_REVIEW_COMMENT),
+        PushEvent(PUSH),
+        ReleaseEvent(RELEASE),
+        WatchEvent(WATCH);
+
+        private final GHEvent event;
+        GitHubEventType(GHEvent event) {
+            this.event = event;
+        }
+
+        /**
+         * Required due to different naming conventions between different GitHub event names for Webhook events and
+         * GitHub events
+         *
+         * @param event
+         *            the github event as a string to convert to Event enum
+         * @return GHEvent
+         */
+        public static GHEvent transformToGHEvent(@Nonnull String event) {
+            try {
+                GitHubEventType gitHubEventType = GitHubEventType.valueOf(event);
+                return gitHubEventType.event;
+            } catch (IllegalArgumentException ignored) {
+                return UNKNOWN;
+            }
+        }
     }
 }

--- a/src/main/java/org/kohsuke/github/GHEvent.java
+++ b/src/main/java/org/kohsuke/github/GHEvent.java
@@ -1,5 +1,7 @@
 package org.kohsuke.github;
 
+import org.kohsuke.github.internal.EnumUtils;
+
 import java.util.Locale;
 
 import javax.annotation.Nonnull;
@@ -94,7 +96,7 @@ public enum GHEvent {
      * @see <a href="https://docs.github.com/en/developers/webhooks-and-events/github-event-types">GitHub event
      *      types</a>
      */
-    public enum GitHubEventType {
+    enum GitHubEventType {
         CommitCommentEvent(COMMIT_COMMENT),
         CreateEvent(CREATE),
         DeleteEvent(DELETE),
@@ -109,7 +111,8 @@ public enum GHEvent {
         PullRequestReviewCommentEvent(PULL_REQUEST_REVIEW_COMMENT),
         PushEvent(PUSH),
         ReleaseEvent(RELEASE),
-        WatchEvent(WATCH);
+        WatchEvent(WATCH),
+        UnknownEvent(UNKNOWN);
 
         private final GHEvent event;
         GitHubEventType(GHEvent event) {
@@ -124,13 +127,8 @@ public enum GHEvent {
          *            the github event as a string to convert to Event enum
          * @return GHEvent
          */
-        public static GHEvent transformToGHEvent(@Nonnull String event) {
-            try {
-                GitHubEventType gitHubEventType = GitHubEventType.valueOf(event);
-                return gitHubEventType.event;
-            } catch (IllegalArgumentException ignored) {
-                return UNKNOWN;
-            }
+        static GHEvent transformToGHEvent(@Nonnull String event) {
+            return EnumUtils.getEnumOrDefault(GitHubEventType.class, event, UnknownEvent).event;
         }
     }
 }

--- a/src/main/java/org/kohsuke/github/GHEventInfo.java
+++ b/src/main/java/org/kohsuke/github/GHEventInfo.java
@@ -2,6 +2,7 @@ package org.kohsuke.github;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.kohsuke.github.GHEvent.GitHubEventType;
 
 import java.io.IOException;
 import java.util.Date;
@@ -46,14 +47,7 @@ public class GHEventInfo extends GitHubInteractiveObject {
      * @return the type
      */
     public GHEvent getType() {
-        String t = type;
-        if (t.endsWith("Event"))
-            t = t.substring(0, t.length() - 5);
-        for (GHEvent e : GHEvent.values()) {
-            if (e.name().replace("_", "").equalsIgnoreCase(t))
-                return e;
-        }
-        return GHEvent.UNKNOWN;
+        return GitHubEventType.transformToGHEvent(type);
     }
 
     GHEventInfo wrapUp(GitHub root) {

--- a/src/main/java/org/kohsuke/github/internal/EnumUtils.java
+++ b/src/main/java/org/kohsuke/github/internal/EnumUtils.java
@@ -30,8 +30,26 @@ public final class EnumUtils {
         if (value == null) {
             return null;
         }
+        return getEnumOrDefault(enumClass, value.toUpperCase(Locale.ROOT), defaultEnum);
+    }
+
+    /**
+     * Returns an enum value matching the value if found, {@code defaultEnum} if the value is null or cannot be matched
+     * to a value of the enum.
+     *
+     * @param <E>
+     *            the type of the enum
+     * @param enumClass
+     *            the type of the enum
+     * @param value
+     *            the value to interpret
+     * @param defaultEnum
+     *            the default enum value if the value doesn't match one of the enum value
+     * @return an enum value
+     */
+    public static <E extends Enum<E>> E getEnumOrDefault(Class<E> enumClass, String value, E defaultEnum) {
         try {
-            return Enum.valueOf(enumClass, value.toUpperCase(Locale.ROOT));
+            return Enum.valueOf(enumClass, value);
         } catch (IllegalArgumentException e) {
             LOGGER.warning("Unknown value " + value + " for enum class " + enumClass.getName() + ", defaulting to "
                     + defaultEnum.name());

--- a/src/test/java/org/kohsuke/github/GHEventTest.java
+++ b/src/test/java/org/kohsuke/github/GHEventTest.java
@@ -26,6 +26,7 @@ public class GHEventTest {
 
     @Test
     public void regressionTest() {
+        assertThat(GitHubEventType.transformToGHEvent("NewlyAddedOrBogusEvent"), is(GHEvent.UNKNOWN));
         for (GitHubEventType gitHubEventType : GitHubEventType.values()) {
             assertThat(GitHubEventType.transformToGHEvent(gitHubEventType.name()),
                     is(oldTransformationFunction(gitHubEventType.name())));

--- a/src/test/java/org/kohsuke/github/GHEventTest.java
+++ b/src/test/java/org/kohsuke/github/GHEventTest.java
@@ -1,0 +1,34 @@
+package org.kohsuke.github;
+
+import org.junit.Test;
+import org.kohsuke.github.GHEvent.GitHubEventType;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class GHEventTest {
+
+    /**
+     * Function from GHEventInfo to transform string event to GHEvent which has been replaced by static mapping due to
+     * complex parsing logic below
+     */
+    private static GHEvent oldTransformationFunction(String t) {
+        if (t.endsWith("Event")) {
+            t = t.substring(0, t.length() - 5);
+        }
+        for (GHEvent e : GHEvent.values()) {
+            if (e.name().replace("_", "").equalsIgnoreCase(t)) {
+                return e;
+            }
+        }
+        return GHEvent.UNKNOWN;
+    }
+
+    @Test
+    public void regressionTest() {
+        for (GitHubEventType gitHubEventType : GitHubEventType.values()) {
+            assertThat(GitHubEventType.transformToGHEvent(gitHubEventType.name()),
+                    is(oldTransformationFunction(gitHubEventType.name())));
+        }
+    }
+}


### PR DESCRIPTION
https://github.com/hub4j/github-api/issues/1099

# Description

Replace complex parsing logic from GHEvent.type to GHEvent with static mapping 
