### PR TITLE
Remove a trailing slash from getWorkflowJob

### DIFF
--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -3073,7 +3073,7 @@ public class GHRepository extends GHObject {
      */
     public GHWorkflowJob getWorkflowJob(long id) throws IOException {
         return root.createRequest()
-                .withUrlPath(getApiTailUrl("/actions/jobs/"), String.valueOf(id))
+                .withUrlPath(getApiTailUrl("/actions/jobs"), String.valueOf(id))
                 .fetch(GHWorkflowJob.class)
                 .wrapUp(this);
     }

--- a/src/test/resources/org/kohsuke/github/GHWorkflowRunTest/wiremock/testJobs/mappings/repos_hub4j-test-org_ghworkflowruntest_actions_jobs__2270858630-10.json
+++ b/src/test/resources/org/kohsuke/github/GHWorkflowRunTest/wiremock/testJobs/mappings/repos_hub4j-test-org_ghworkflowruntest_actions_jobs__2270858630-10.json
@@ -2,7 +2,7 @@
   "id": "3e411914-13ab-4047-9b13-8394a37a3f62",
   "name": "repos_hub4j-test-org_ghworkflowruntest_actions_jobs__2270858630",
   "request": {
-    "url": "/repos/hub4j-test-org/GHWorkflowRunTest/actions/jobs//2270858630",
+    "url": "/repos/hub4j-test-org/GHWorkflowRunTest/actions/jobs/2270858630",
     "method": "GET",
     "headers": {
       "Accept": {


### PR DESCRIPTION
# Description
I found the request URL looks like `https://api.github.com/repos/owner/repo/actions/jobs//xxx` and the URL contains `//` between `jobs` and its id. I looked into it and found we need to remove a trailing slash from the getWorkflowJob method. Thank you for your review!

Currently, the API returned 404 when we use the getWorkflowJob method so I'd really appreciate it if you would review and release this change soon.

<!-- Describe your change here -->

# Before submitting a PR:
We love getting PRs, but we hate asking people for the same basic changes every time.

- [x] Push your changes to a branch other than `main`. Create your PR from that branch.
- [x] Add JavaDocs and other comments
- [x] Write tests that run and pass in CI. See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to capture snapshot data.
- [x] Run `mvn -D enable-ci clean install site` locally. If this command doesn't succeed, your change will not pass CI.

# When creating a PR: 

- [x] Fill in the "Description" above.
- [x] Enable "Allow edits from maintainers".
