### PR TITLE
Fix withCredetials() to correctly detect missing creds

### DIFF
--- a/src/main/java/org/kohsuke/github/GitHubBuilder.java
+++ b/src/main/java/org/kohsuke/github/GitHubBuilder.java
@@ -60,13 +60,13 @@ public class GitHubBuilder implements Cloneable {
 
         builder = fromEnvironment();
 
-        if (builder.authorizationProvider != null)
+        if (builder.authorizationProvider != AuthorizationProvider.ANONYMOUS)
             return builder;
 
         try {
             builder = fromPropertyFile();
 
-            if (builder.authorizationProvider != null)
+            if (builder.authorizationProvider != AuthorizationProvider.ANONYMOUS)
                 return builder;
         } catch (FileNotFoundException e) {
             // fall through

--- a/src/main/java/org/kohsuke/github/GitHubBuilder.java
+++ b/src/main/java/org/kohsuke/github/GitHubBuilder.java
@@ -24,6 +24,9 @@ import javax.annotation.Nonnull;
  */
 public class GitHubBuilder implements Cloneable {
 
+    // for testing
+    static File HOME_DIRECTORY = null;
+
     // default scoped so unit tests can read them.
     /* private */ String endpoint = GitHubClient.GITHUB_URL;
 
@@ -178,7 +181,7 @@ public class GitHubBuilder implements Cloneable {
      *             the io exception
      */
     public static GitHubBuilder fromPropertyFile() throws IOException {
-        File homeDir = new File(System.getProperty("user.home"));
+        File homeDir = HOME_DIRECTORY != null ? HOME_DIRECTORY : new File(System.getProperty("user.home"));
         File propertyFile = new File(homeDir, ".github");
         return fromPropertyFile(propertyFile.getPath());
     }

--- a/src/test/java/org/kohsuke/github/GitHubConnectionTest.java
+++ b/src/test/java/org/kohsuke/github/GitHubConnectionTest.java
@@ -1,5 +1,6 @@
 package org.kohsuke.github;
 
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.Assume;
 import org.junit.Test;
 import org.kohsuke.github.authorization.AuthorizationProvider;
@@ -145,6 +146,7 @@ public class GitHubConnectionTest extends AbstractGitHubWireMockTest {
     public void testGitHubBuilderFromCredentialsWithEnvironment() throws IOException {
         // we disable this test for JDK 16+ as the current hacks in setupEnvironment() don't work with JDK 16+
         Assume.assumeThat(Double.valueOf(System.getProperty("java.specification.version")), lessThan(16.0));
+        Assume.assumeFalse(SystemUtils.IS_OS_WINDOWS);
 
         Map<String, String> props = new HashMap<String, String>();
 
@@ -188,13 +190,14 @@ public class GitHubConnectionTest extends AbstractGitHubWireMockTest {
     public void testGitHubBuilderFromCredentialsWithPropertyFile() throws IOException {
         // we disable this test for JDK 16+ as the current hacks in setupEnvironment() don't work with JDK 16+
         Assume.assumeThat(Double.valueOf(System.getProperty("java.specification.version")), lessThan(16.0));
+        Assume.assumeFalse(SystemUtils.IS_OS_WINDOWS);
 
         Map<String, String> props = new HashMap<String, String>();
 
         // Clear the environment
         setupEnvironment(props);
-        GitHubBuilder.HOME_DIRECTORY = new File(getTestDirectory());
         try {
+            GitHubBuilder.HOME_DIRECTORY = new File(getTestDirectory());
             try {
                 GitHubBuilder builder = GitHubBuilder.fromCredentials();
                 fail();
@@ -245,6 +248,7 @@ public class GitHubConnectionTest extends AbstractGitHubWireMockTest {
                     equalTo("Basic Ym9ndXMgbG9naW46Ym9ndXMgd2VhayBwYXNzd29yZA=="));
             assertThat(((UserAuthorizationProvider) builder.authorizationProvider).getLogin(), equalTo("bogus login"));
         } finally {
+            GitHubBuilder.HOME_DIRECTORY = null;
             File propertyFile = new File(getTestDirectory(), ".github");
             propertyFile.delete();
         }


### PR DESCRIPTION

# Description

Fixes #1155

@gsmet @hcoles

If you want to test this fix manually against #1156 or #1157 , that would be helpful. 

# Before submitting a PR:
We love getting PRs, but we hate asking people for the same basic changes every time.

- [x] Push your changes to a branch other than `main`. Create your PR from that branch.
- [x] Add JavaDocs and other comments
- [x] Write tests that run and pass in CI. See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to capture snapshot data.
- [x] Run `mvn -D enable-ci clean install site` locally. If this command doesn't succeed, your change will not pass CI.

# When creating a PR: 

- [x] Fill in the "Description" above.
- [x] Enable "Allow edits from maintainers".
