### PR TITLE
Update javadocs for GHPullRequestFileDetail

### DIFF
--- a/src/main/java/org/kohsuke/github/GHPullRequest.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequest.java
@@ -388,9 +388,13 @@ public class GHPullRequest extends GHIssue implements Refreshable {
     }
 
     /**
-     * Retrieves all the files associated to this pull request.
+     * Retrieves all the files associated to this pull request. The paginated response returns 30 files per page by
+     * default.
      *
      * @return the paged iterable
+     *
+     * @see <a href="https://docs.github.com/en/rest/reference/pulls#list-pull-requests-files">List pull requests
+     *      files</a>
      */
     public PagedIterable<GHPullRequestFileDetail> listFiles() {
         return root.createRequest()

--- a/src/main/java/org/kohsuke/github/GHPullRequestFileDetail.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequestFileDetail.java
@@ -30,6 +30,7 @@ import java.net.URL;
  *
  * @author Julien Henry
  * @see GHPullRequest#listFiles() GHPullRequest#listFiles()
+ * @see <a href="https://docs.github.com/en/rest/reference/pulls#list-pull-requests-files">List pull requests files</a>
  */
 public class GHPullRequestFileDetail {
 
@@ -46,7 +47,10 @@ public class GHPullRequestFileDetail {
     String previous_filename;
 
     /**
-     * Gets sha.
+     * Gets sha of the file (not commit sha).
+     *
+     * @see <a href="https://docs.github.com/en/rest/reference/pulls#list-pull-requests-files">List pull requests
+     *      files</a>
      *
      * @return the sha
      */
@@ -64,7 +68,7 @@ public class GHPullRequestFileDetail {
     }
 
     /**
-     * Gets status.
+     * Gets status (added/modified/deleted)
      *
      * @return the status
      */


### PR DESCRIPTION
# Description

In order to fix https://github.com/hub4j/github-api/issues/486, JavaDocs for GHPullRequestFileDetail was updated.

Fixes #486.