### PR TITLE
Move Malformed URL catching to core

### DIFF
--- a/src/main/java/org/kohsuke/github/GHAppInstallation.java
+++ b/src/main/java/org/kohsuke/github/GHAppInstallation.java
@@ -5,7 +5,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.kohsuke.github.internal.EnumUtils;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Collections;
 import java.util.List;
@@ -123,11 +122,7 @@ public class GHAppInstallation extends GHObject {
     public PagedSearchIterable<GHRepository> listRepositories() {
         GitHubRequest request;
 
-        try {
-            request = root().createRequest().withPreview(MACHINE_MAN).withUrlPath("/installation/repositories").build();
-        } catch (MalformedURLException e) {
-            throw new GHException("", e);
-        }
+        request = root().createRequest().withPreview(MACHINE_MAN).withUrlPath("/installation/repositories").build();
 
         return new PagedSearchIterable<>(root(), request, GHAppInstallationRepositoryResult.class);
     }

--- a/src/main/java/org/kohsuke/github/GHAppInstallationsIterable.java
+++ b/src/main/java/org/kohsuke/github/GHAppInstallationsIterable.java
@@ -1,6 +1,5 @@
 package org.kohsuke.github;
 
-import java.net.MalformedURLException;
 import java.util.Iterator;
 
 import javax.annotation.Nonnull;
@@ -20,14 +19,10 @@ class GHAppInstallationsIterable extends PagedIterable<GHAppInstallation> {
     @Nonnull
     @Override
     public PagedIterator<GHAppInstallation> _iterator(int pageSize) {
-        try {
-            final GitHubRequest request = root.createRequest().withUrlPath(APP_INSTALLATIONS_URL).build();
-            return new PagedIterator<>(
-                    adapt(GitHubPageIterator.create(root.getClient(), GHAppInstallationsPage.class, request, pageSize)),
-                    null);
-        } catch (MalformedURLException e) {
-            throw new GHException("Malformed URL", e);
-        }
+        final GitHubRequest request = root.createRequest().withUrlPath(APP_INSTALLATIONS_URL).build();
+        return new PagedIterator<>(
+                adapt(GitHubPageIterator.create(root.getClient(), GHAppInstallationsPage.class, request, pageSize)),
+                null);
     }
 
     protected Iterator<GHAppInstallation[]> adapt(final Iterator<GHAppInstallationsPage> base) {

--- a/src/main/java/org/kohsuke/github/GHArtifactsIterable.java
+++ b/src/main/java/org/kohsuke/github/GHArtifactsIterable.java
@@ -1,6 +1,5 @@
 package org.kohsuke.github;
 
-import java.net.MalformedURLException;
 import java.util.Iterator;
 
 import javax.annotation.Nonnull;
@@ -16,11 +15,7 @@ class GHArtifactsIterable extends PagedIterable<GHArtifact> {
 
     public GHArtifactsIterable(GHRepository owner, GitHubRequest.Builder<?> requestBuilder) {
         this.owner = owner;
-        try {
-            this.request = requestBuilder.build();
-        } catch (MalformedURLException e) {
-            throw new GHException("Malformed URL", e);
-        }
+        this.request = requestBuilder.build();
     }
 
     @Nonnull

--- a/src/main/java/org/kohsuke/github/GHCompare.java
+++ b/src/main/java/org/kohsuke/github/GHCompare.java
@@ -6,7 +6,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Collections;
 import java.util.Iterator;
@@ -362,23 +361,19 @@ public class GHCompare {
         @Nonnull
         @Override
         public PagedIterator<Commit> _iterator(int pageSize) {
-            try {
-                GitHubRequest request = owner.root()
-                        .createRequest()
-                        .injectMappingValue("GHCompare_usePaginatedCommits", usePaginatedCommits)
-                        .withUrlPath(owner.getApiTailUrl(url.substring(url.lastIndexOf("/compare/"))))
-                        .build();
+            GitHubRequest request = owner.root()
+                    .createRequest()
+                    .injectMappingValue("GHCompare_usePaginatedCommits", usePaginatedCommits)
+                    .withUrlPath(owner.getApiTailUrl(url.substring(url.lastIndexOf("/compare/"))))
+                    .build();
 
-                // page_size must be set for GHCompare commit pagination
-                if (pageSize == 0) {
-                    pageSize = 10;
-                }
-                return new PagedIterator<>(
-                        adapt(GitHubPageIterator.create(owner.root().getClient(), GHCompare.class, request, pageSize)),
-                        item -> item.wrapUp(owner));
-            } catch (MalformedURLException e) {
-                throw new GHException("Malformed URL", e);
+            // page_size must be set for GHCompare commit pagination
+            if (pageSize == 0) {
+                pageSize = 10;
             }
+            return new PagedIterator<>(
+                    adapt(GitHubPageIterator.create(owner.root().getClient(), GHCompare.class, request, pageSize)),
+                    item -> item.wrapUp(owner));
         }
 
         protected Iterator<Commit[]> adapt(final Iterator<GHCompare> base) {

--- a/src/main/java/org/kohsuke/github/GHPerson.java
+++ b/src/main/java/org/kohsuke/github/GHPerson.java
@@ -2,7 +2,6 @@ package org.kohsuke.github;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Collections;
 import java.util.Date;
@@ -115,15 +114,11 @@ public abstract class GHPerson extends GHObject {
     public synchronized Iterable<List<GHRepository>> iterateRepositories(final int pageSize) {
         return () -> {
             final PagedIterator<GHRepository> pager;
-            try {
-                GitHubPageIterator<GHRepository[]> iterator = GitHubPageIterator.create(root().getClient(),
-                        GHRepository[].class,
-                        root().createRequest().withUrlPath("users", login, "repos").build(),
-                        pageSize);
-                pager = new PagedIterator<>(iterator, null);
-            } catch (MalformedURLException e) {
-                throw new GHException("Unable to build GitHub API URL", e);
-            }
+            GitHubPageIterator<GHRepository[]> iterator = GitHubPageIterator.create(root().getClient(),
+                    GHRepository[].class,
+                    root().createRequest().withUrlPath("users", login, "repos").build(),
+                    pageSize);
+            pager = new PagedIterator<>(iterator, null);
 
             return new Iterator<List<GHRepository>>() {
                 public boolean hasNext() {

--- a/src/main/java/org/kohsuke/github/GHSearchBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHSearchBuilder.java
@@ -2,7 +2,6 @@ package org.kohsuke.github;
 
 import org.apache.commons.lang3.StringUtils;
 
-import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -47,11 +46,7 @@ public abstract class GHSearchBuilder<T> extends GHQueryBuilder<T> {
     public PagedSearchIterable<T> list() {
 
         req.set("q", StringUtils.join(terms, " "));
-        try {
-            return new PagedSearchIterable<>(root(), req.build(), receiverType);
-        } catch (MalformedURLException e) {
-            throw new GHException("", e);
-        }
+        return new PagedSearchIterable<>(root(), req.build(), receiverType);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHWorkflowJobQueryBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHWorkflowJobQueryBuilder.java
@@ -1,7 +1,5 @@
 package org.kohsuke.github;
 
-import java.net.MalformedURLException;
-
 /**
  * Lists up jobs of a workflow run with some filtering.
  *
@@ -38,10 +36,6 @@ public class GHWorkflowJobQueryBuilder extends GHQueryBuilder<GHWorkflowJob> {
 
     @Override
     public PagedIterable<GHWorkflowJob> list() {
-        try {
-            return new GHWorkflowJobsIterable(repo, req.build());
-        } catch (MalformedURLException e) {
-            throw new GHException(e.getMessage(), e);
-        }
+        return new GHWorkflowJobsIterable(repo, req.build());
     }
 }

--- a/src/main/java/org/kohsuke/github/GHWorkflowRunsIterable.java
+++ b/src/main/java/org/kohsuke/github/GHWorkflowRunsIterable.java
@@ -1,6 +1,5 @@
 package org.kohsuke.github;
 
-import java.net.MalformedURLException;
 import java.util.Iterator;
 
 import javax.annotation.Nonnull;
@@ -16,11 +15,7 @@ class GHWorkflowRunsIterable extends PagedIterable<GHWorkflowRun> {
 
     public GHWorkflowRunsIterable(GHRepository owner, GitHubRequest.Builder<?> requestBuilder) {
         this.owner = owner;
-        try {
-            this.request = requestBuilder.build();
-        } catch (MalformedURLException e) {
-            throw new GHException("Malformed URL", e);
-        }
+        this.request = requestBuilder.build();
     }
 
     @Nonnull

--- a/src/main/java/org/kohsuke/github/GHWorkflowsIterable.java
+++ b/src/main/java/org/kohsuke/github/GHWorkflowsIterable.java
@@ -1,6 +1,5 @@
 package org.kohsuke.github;
 
-import java.net.MalformedURLException;
 import java.util.Iterator;
 
 import javax.annotation.Nonnull;
@@ -20,19 +19,14 @@ class GHWorkflowsIterable extends PagedIterable<GHWorkflow> {
     @Nonnull
     @Override
     public PagedIterator<GHWorkflow> _iterator(int pageSize) {
-        try {
-            GitHubRequest request = owner.root()
-                    .createRequest()
-                    .withUrlPath(owner.getApiTailUrl("actions/workflows"))
-                    .build();
+        GitHubRequest request = owner.root()
+                .createRequest()
+                .withUrlPath(owner.getApiTailUrl("actions/workflows"))
+                .build();
 
-            return new PagedIterator<>(
-                    adapt(GitHubPageIterator
-                            .create(owner.root().getClient(), GHWorkflowsPage.class, request, pageSize)),
-                    null);
-        } catch (MalformedURLException e) {
-            throw new GHException("Malformed URL", e);
-        }
+        return new PagedIterator<>(
+                adapt(GitHubPageIterator.create(owner.root().getClient(), GHWorkflowsPage.class, request, pageSize)),
+                null);
     }
 
     protected Iterator<GHWorkflow[]> adapt(final Iterator<GHWorkflowsPage> base) {

--- a/src/main/java/org/kohsuke/github/GitHubPageIterator.java
+++ b/src/main/java/org/kohsuke/github/GitHubPageIterator.java
@@ -72,16 +72,12 @@ class GitHubPageIterator<T> implements Iterator<T> {
      */
     static <T> GitHubPageIterator<T> create(GitHubClient client, Class<T> type, GitHubRequest request, int pageSize) {
 
-        try {
-            if (pageSize > 0) {
-                GitHubRequest.Builder<?> builder = request.toBuilder().with("per_page", pageSize);
-                request = builder.build();
-            }
-
-            return new GitHubPageIterator<>(client, type, request);
-        } catch (MalformedURLException e) {
-            throw new GHException("Unable to build GitHub API URL", e);
+        if (pageSize > 0) {
+            GitHubRequest.Builder<?> builder = request.toBuilder().with("per_page", pageSize);
+            request = builder.build();
         }
+
+        return new GitHubPageIterator<>(client, type, request);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GitHubRequest.java
+++ b/src/main/java/org/kohsuke/github/GitHubRequest.java
@@ -92,21 +92,19 @@ class GitHubRequest {
     @Nonnull
     static URL getApiURL(String apiUrl, String tailApiUrl) {
         try {
-            if (tailApiUrl.startsWith("/")) {
-                if ("github.com".equals(apiUrl)) {// backward compatibility
-                    return new URL(GitHubClient.GITHUB_URL + tailApiUrl);
-                } else {
-                    return new URL(apiUrl + tailApiUrl);
-                }
-            } else {
-                return new URL(tailApiUrl);
+            if (!tailApiUrl.startsWith("/")) {
+                apiUrl = "";
+            } else if ("github.com".equals(apiUrl)) {
+                // backward compatibility
+                apiUrl = GitHubClient.GITHUB_URL;
             }
-        } catch (MalformedURLException e) {
+            return new URL(apiUrl + tailApiUrl);
+        } catch (Exception e) {
             // The data going into constructing this URL should be controlled by the GitHub API framework,
             // so a malformed URL here is a framework runtime error.
             // All callers of this method ended up wrapping and throwing GHException,
             // indicating the functionality should be moved to the common code path.
-            throw new GHException("Malformed URL ", e);
+            throw new GHException("Unable to build GitHub API URL", e);
         }
     }
 

--- a/src/main/java/org/kohsuke/github/GitHubRequest.java
+++ b/src/main/java/org/kohsuke/github/GitHubRequest.java
@@ -60,7 +60,7 @@ class GitHubRequest {
             @Nonnull String method,
             @Nonnull RateLimitTarget rateLimitTarget,
             @CheckForNull InputStream body,
-            boolean forceBody) throws MalformedURLException {
+            boolean forceBody) {
         this.args = Collections.unmodifiableList(new ArrayList<>(args));
         this.headers = Collections.unmodifiableMap(new LinkedHashMap<>(headers));
         this.injectedMappingValues = Collections.unmodifiableMap(new LinkedHashMap<>(injectedMappingValues));
@@ -85,17 +85,28 @@ class GitHubRequest {
 
     /**
      * Gets the final GitHub API URL.
+     *
+     * @throws GHException
+     *             wrapping a {@link MalformedURLException} if the GitHub API URL cannot be constructed
      */
     @Nonnull
-    static URL getApiURL(String apiUrl, String tailApiUrl) throws MalformedURLException {
-        if (tailApiUrl.startsWith("/")) {
-            if ("github.com".equals(apiUrl)) {// backward compatibility
-                return new URL(GitHubClient.GITHUB_URL + tailApiUrl);
+    static URL getApiURL(String apiUrl, String tailApiUrl) {
+        try {
+            if (tailApiUrl.startsWith("/")) {
+                if ("github.com".equals(apiUrl)) {// backward compatibility
+                    return new URL(GitHubClient.GITHUB_URL + tailApiUrl);
+                } else {
+                    return new URL(apiUrl + tailApiUrl);
+                }
             } else {
-                return new URL(apiUrl + tailApiUrl);
+                return new URL(tailApiUrl);
             }
-        } else {
-            return new URL(tailApiUrl);
+        } catch (MalformedURLException e) {
+            // The data going into constructing this URL should be controlled by the GitHub API framework,
+            // so a malformed URL here is a framework runtime error.
+            // All callers of this method ended up wrapping and throwing GHException,
+            // indicating the functionality should be moved to the common code path.
+            throw new GHException("Malformed URL ", e);
         }
     }
 
@@ -349,10 +360,10 @@ class GitHubRequest {
          * Builds a {@link GitHubRequest} from this builder.
          *
          * @return a {@link GitHubRequest}
-         * @throws MalformedURLException
-         *             if the GitHub API URL cannot be constructed
+         * @throws GHException
+         *             wrapping a {@link MalformedURLException} if the GitHub API URL cannot be constructed
          */
-        public GitHubRequest build() throws MalformedURLException {
+        public GitHubRequest build() {
             return new GitHubRequest(args,
                     headers,
                     injectedMappingValues,

--- a/src/main/java/org/kohsuke/github/Requester.java
+++ b/src/main/java/org/kohsuke/github/Requester.java
@@ -30,7 +30,6 @@ import org.kohsuke.github.function.InputStreamFunction;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.MalformedURLException;
 import java.util.Iterator;
 import java.util.function.Consumer;
 
@@ -151,11 +150,7 @@ class Requester extends GitHubRequest.Builder<Requester> {
      * @return the {@link PagedIterable} for this builder.
      */
     public <R> PagedIterable<R> toIterable(Class<R[]> type, Consumer<R> itemInitializer) {
-        try {
-            return new GitHubPageContentsIterable<>(client, build(), type, itemInitializer);
-        } catch (MalformedURLException e) {
-            throw new GHException(e.getMessage(), e);
-        }
+        return new GitHubPageContentsIterable<>(client, build(), type, itemInitializer);
 
     }
 }

--- a/src/test/java/org/kohsuke/github/GitHubStaticTest.java
+++ b/src/test/java/org/kohsuke/github/GitHubStaticTest.java
@@ -1,7 +1,9 @@
 package org.kohsuke.github;
 
+import org.junit.Assert;
 import org.junit.Test;
 
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.text.SimpleDateFormat;
 import java.time.Duration;
@@ -341,6 +343,38 @@ public class GitHubStaticTest extends AbstractGitHubWireMockTest {
 
         String readRepoString = GitHub.getMappingObjectWriter().writeValueAsString(readRepo);
         assertThat(readRepoString, equalTo(repoString));
+
+    }
+
+    @Test
+    public void testGitHubRequest_getApiURL() throws Exception {
+        assertThat(GitHubRequest.getApiURL("github.com", "/endpoint").toString(),
+                equalTo("https://api.github.com/endpoint"));
+
+        // This URL is completely invalid but doesn't throw
+        assertThat(GitHubRequest.getApiURL("github.com", "//endpoint&?").toString(),
+                equalTo("https://api.github.com//endpoint&?"));
+
+        assertThat(GitHubRequest.getApiURL("ftp://whoa.github.com", "/endpoint").toString(),
+                equalTo("ftp://whoa.github.com/endpoint"));
+        assertThat(GitHubRequest.getApiURL(null, "ftp://api.test.github.com/endpoint").toString(),
+                equalTo("ftp://api.test.github.com/endpoint"));
+
+        GHException e;
+        e = Assert.assertThrows(GHException.class,
+                () -> GitHubRequest.getApiURL("gopher://whoa.github.com", "/endpoint"));
+        assertThat(e.getMessage(), equalTo("Unable to build GitHub API URL"));
+        assertThat(e.getCause(), instanceOf(MalformedURLException.class));
+        assertThat(e.getCause().getMessage(), equalTo("unknown protocol: gopher"));
+
+        e = Assert.assertThrows(GHException.class, () -> GitHubRequest.getApiURL("bogus", "/endpoint"));
+        assertThat(e.getCause(), instanceOf(MalformedURLException.class));
+        assertThat(e.getCause().getMessage(), equalTo("no protocol: bogus/endpoint"));
+
+        e = Assert.assertThrows(GHException.class,
+                () -> GitHubRequest.getApiURL(null, "gopher://api.test.github.com/endpoint"));
+        assertThat(e.getCause(), instanceOf(MalformedURLException.class));
+        assertThat(e.getCause().getMessage(), equalTo("unknown protocol: gopher"));
 
     }
 


### PR DESCRIPTION
# Description
This `MalformedURLException` is always caught and re-thrown as `GHException`. 
Converting that to be the standard behavior. 

# Before submitting a PR:
We love getting PRs, but we hate asking people for the same basic changes every time.

- [ ] Push your changes to a branch other than `main`. Create your PR from that branch.
- [ ] Add JavaDocs and other comments
- [ ] Write tests that run and pass in CI. See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to capture snapshot data.
- [ ] Run `mvn -D enable-ci clean install site` locally. If this command doesn't succeed, your change will not pass CI.

# When creating a PR: 

- [ ] Fill in the "Description" above.
- [ ] Enable "Allow edits from maintainers".
