### PR TITLE
Using TCK Tested JDK builds of OpenJDK

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -13,14 +13,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 16 ]
+        java: [ 16, 17 ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK
         uses: actions/setup-java@v2
         with:
           java-version: ${{ matrix.java }}
-          distribution: 'adopt'
+          distribution: 'zulu'
       - name: Cached .m2
         uses: actions/cache@v2.1.6
         with:
@@ -39,14 +39,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu, windows ]
-        java: [ 8, 11, 16 ]
+        java: [ 8.0.192, 8, 11, 11.0.3, 16, 17 ]
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK
       uses: actions/setup-java@v2
       with:
         java-version: ${{ matrix.java }}
-        distribution: 'adopt'
+        distribution: 'zulu'
     - uses: actions/cache@v2.1.6
       with:
         path: ~/.m2/repository


### PR DESCRIPTION
The AdoptOpenJDK has been discontinued since July 2021. When using Zulu 
you get all the latest updated (TCK Tested) builds for all versions of OpenJDK. 

As good practice I added major fixed versions of JDK 8.0.192, 11.0.3. 

An example is when 8.0.192 passes(green) and 8 (latest) fails (red) you know it was the build version not your code that caused the build to fail.

While Temurin is the successor to AdoptOpenJDK it does not support archived versions prior to sept. 2021. Azul has all archived versions and the latest releases.

# Description

<!-- Describe your change here -->

# Before submitting a PR:
We love getting PRs, but we hate asking people for the same basic changes every time.

- [ ] Push your changes to a branch other than `main`. Create your PR from that branch.
- [ ] Add JavaDocs and other comments
- [ ] Write tests that run and pass in CI. See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to capture snapshot data.
- [ ] Run `mvn -D enable-ci clean install site` locally. If this command doesn't succeed, your change will not pass CI.

# When creating a PR: 

- [ ] Fill in the "Description" above.
- [ ] Enable "Allow edits from maintainers".
