### PR TITLE
Removed deprecated from javadoc

### DIFF
--- a/src/main/java/org/kohsuke/github/GHDeploymentState.java
+++ b/src/main/java/org/kohsuke/github/GHDeploymentState.java
@@ -13,24 +13,18 @@ public enum GHDeploymentState {
 
     /**
      * The state of the deployment currently reflects it's in progress.
-     *
-     * @deprecated until preview feature has graduated to stable
      */
     @Preview(Previews.FLASH)
     IN_PROGRESS,
 
     /**
      * The state of the deployment currently reflects it's queued up for processing.
-     *
-     * @deprecated until preview feature has graduated to stable
      */
     @Preview(Previews.FLASH)
     QUEUED,
 
     /**
      * The state of the deployment currently reflects it's no longer active.
-     *
-     * @deprecated until preview feature has graduated to stable
      */
     @Preview(Previews.ANT_MAN)
     INACTIVE


### PR DESCRIPTION
# Description
Bug [#1269](https://github.com/hub4j/github-api/issues/1269). Removed `@deprecated` from the javadoc

# Before submitting a PR:
We love getting PRs, but we hate asking people for the same basic changes every time.

- [x] Push your changes to a branch other than `main`. Create your PR from that branch.
- [x] Add JavaDocs and other comments
- [ ] Write tests that run and pass in CI. See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to capture snapshot data.
- [ ] Run `mvn -D enable-ci clean install site` locally. If this command doesn't succeed, your change will not pass CI.

# When creating a PR: 

- [x] Fill in the "Description" above.
- [x] Enable "Allow edits from maintainers".
