### PR TITLE
Deprecate limit handlers using HttpURLConnection

### DIFF
--- a/src/main/java/org/kohsuke/github/AbuseLimitHandler.java
+++ b/src/main/java/org/kohsuke/github/AbuseLimitHandler.java
@@ -12,11 +12,13 @@ import javax.annotation.Nonnull;
  * Pluggable strategy to determine what to do when the API abuse limit is hit.
  *
  * @author Kohsuke Kawaguchi
- * @see GitHubBuilder#withAbuseLimitHandler(AbuseLimitHandler) GitHubBuilder#withAbuseLimitHandler(AbuseLimitHandler)
+ * @see GitHubBuilder#withAbuseLimitHandler(GitHubAbuseLimitHandler)
+ *      GitHubBuilder#withAbuseLimitHandler(GitHubAbuseLimitHandler)
  * @see <a href="https://developer.github.com/v3/#abuse-rate-limits">documentation</a>
  * @see RateLimitHandler
  */
-public abstract class AbuseLimitHandler {
+@Deprecated
+public abstract class AbuseLimitHandler extends GitHubAbuseLimitHandler {
 
     /**
      * Called when the library encounters HTTP error indicating that the API abuse limit is reached.
@@ -37,7 +39,7 @@ public abstract class AbuseLimitHandler {
      *
      */
     public void onError(@Nonnull GitHubConnectorResponse connectorResponse) throws IOException {
-        GHIOException e = new HttpException("Abuse limit violation",
+        GHIOException e = new HttpException("Abuse limit reached",
                 connectorResponse.statusCode(),
                 connectorResponse.header("Status"),
                 connectorResponse.request().url().toString()).withResponseHeaderFields(connectorResponse.allHeaders());
@@ -66,12 +68,12 @@ public abstract class AbuseLimitHandler {
      *
      */
     @Deprecated
-    public void onError(IOException e, HttpURLConnection uc) throws IOException {
-    }
+    public abstract void onError(IOException e, HttpURLConnection uc) throws IOException;
 
     /**
      * Wait until the API abuse "wait time" is passed.
      */
+    @Deprecated
     public static final AbuseLimitHandler WAIT = new AbuseLimitHandler() {
         @Override
         public void onError(IOException e, HttpURLConnection uc) throws IOException {
@@ -94,10 +96,11 @@ public abstract class AbuseLimitHandler {
     /**
      * Fail immediately.
      */
+    @Deprecated
     public static final AbuseLimitHandler FAIL = new AbuseLimitHandler() {
         @Override
         public void onError(IOException e, HttpURLConnection uc) throws IOException {
-            throw (IOException) new IOException("Abuse limit reached").initCause(e);
+            throw e;
         }
     };
 }

--- a/src/main/java/org/kohsuke/github/GitHub.java
+++ b/src/main/java/org/kohsuke/github/GitHub.java
@@ -113,8 +113,8 @@ public class GitHub {
      */
     GitHub(String apiUrl,
             GitHubConnector connector,
-            RateLimitHandler rateLimitHandler,
-            AbuseLimitHandler abuseLimitHandler,
+            GitHubRateLimitHandler rateLimitHandler,
+            GitHubAbuseLimitHandler abuseLimitHandler,
             GitHubRateLimitChecker rateLimitChecker,
             AuthorizationProvider authorizationProvider) throws IOException {
         if (authorizationProvider instanceof DependentAuthorizationProvider) {

--- a/src/main/java/org/kohsuke/github/GitHubAbuseLimitHandler.java
+++ b/src/main/java/org/kohsuke/github/GitHubAbuseLimitHandler.java
@@ -1,0 +1,44 @@
+package org.kohsuke.github;
+
+import org.kohsuke.github.connector.GitHubConnectorResponse;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Pluggable strategy to determine what to do when the API rate limit is reached.
+ *
+ * @author Kohsuke Kawaguchi
+ * @see GitHubBuilder#withAbuseLimitHandler(AbuseLimitHandler) GitHubBuilder#withRateLimitHandler(AbuseLimitHandler)
+ * @see GitHubRateLimitHandler
+ */
+public abstract class GitHubAbuseLimitHandler extends GitHubConnectorResponseErrorHandler {
+
+    @Override
+    boolean isError(@Nonnull GitHubConnectorResponse connectorResponse) throws IOException {
+        return connectorResponse.statusCode() == HttpURLConnection.HTTP_FORBIDDEN
+                && connectorResponse.header("Retry-After") != null;
+    }
+
+    /**
+     * Called when the library encounters HTTP error indicating that the API abuse limit is reached.
+     *
+     * <p>
+     * Any exception thrown from this method will cause the request to fail, and the caller of github-api will receive
+     * an exception. If this method returns normally, another request will be attempted. For that to make sense, the
+     * implementation needs to wait for some time.
+     *
+     * @param connectorResponse
+     *            Response information for this request.
+     * @throws IOException
+     *             on failure
+     * @see <a href="https://developer.github.com/v3/#abuse-rate-limits">API documentation from GitHub</a>
+     * @see <a href=
+     *      "https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits">Dealing
+     *      with abuse rate limits</a>
+     *
+     */
+    public abstract void onError(@Nonnull GitHubConnectorResponse connectorResponse) throws IOException;
+}

--- a/src/main/java/org/kohsuke/github/GitHubConnectorResponseErrorHandler.java
+++ b/src/main/java/org/kohsuke/github/GitHubConnectorResponseErrorHandler.java
@@ -1,0 +1,61 @@
+package org.kohsuke.github;
+
+import org.jetbrains.annotations.NotNull;
+import org.kohsuke.github.connector.GitHubConnectorResponse;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import javax.annotation.Nonnull;
+
+import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
+
+/**
+ * Pluggable strategy to determine what to detect and choose what to do when various errors occur during an http
+ * request.
+ *
+ * @author Liam Newman
+ */
+abstract class GitHubConnectorResponseErrorHandler {
+
+    /**
+     * Called to detect an error handled by this handler.
+     *
+     * @return {@code true} if there is an error and {@link #onError(GitHubConnectorResponse)} should be called
+     */
+    abstract boolean isError(@Nonnull GitHubConnectorResponse connectorResponse) throws IOException;
+
+    /**
+     * Called when the library encounters HTTP error matching {@link #isError(GitHubConnectorResponse)}
+     *
+     * <p>
+     * Any exception thrown from this method will cause the request to fail, and the caller of github-api will receive
+     * an exception. If this method returns normally, another request will be attempted. For that to make sense, the
+     * implementation needs to wait for some time.
+     *
+     * @param connectorResponse
+     *            Response information for this request.
+     *
+     * @throws IOException
+     *             the io exception
+     * @see <a href="https://developer.github.com/v3/#rate-limiting">API documentation from GitHub</a>
+     */
+    public abstract void onError(@Nonnull GitHubConnectorResponse connectorResponse) throws IOException;
+
+    static GitHubConnectorResponseErrorHandler STATUS_HTTP_BAD_REQUEST_OR_GREATER = new GitHubConnectorResponseErrorHandler() {
+        @Override
+        public boolean isError(@NotNull GitHubConnectorResponse connectorResponse) throws IOException {
+            return connectorResponse.statusCode() >= HTTP_BAD_REQUEST;
+        }
+
+        @Override
+        public void onError(@NotNull GitHubConnectorResponse connectorResponse) throws IOException {
+            if (connectorResponse.statusCode() == HTTP_NOT_FOUND) {
+                throw new FileNotFoundException(connectorResponse.request().url().toString());
+            } else {
+                throw new HttpException(connectorResponse);
+            }
+        }
+    };
+}

--- a/src/main/java/org/kohsuke/github/GitHubRateLimitHandler.java
+++ b/src/main/java/org/kohsuke/github/GitHubRateLimitHandler.java
@@ -1,0 +1,42 @@
+package org.kohsuke.github;
+
+import org.jetbrains.annotations.NotNull;
+import org.kohsuke.github.connector.GitHubConnectorResponse;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Pluggable strategy to determine what to do when the API rate limit is reached.
+ *
+ * @author Kohsuke Kawaguchi
+ * @see GitHubBuilder#withRateLimitHandler(RateLimitHandler) GitHubBuilder#withRateLimitHandler(RateLimitHandler)
+ * @see GitHubAbuseLimitHandler
+ */
+public abstract class GitHubRateLimitHandler extends GitHubConnectorResponseErrorHandler {
+
+    @Override
+    boolean isError(@NotNull GitHubConnectorResponse connectorResponse) throws IOException {
+        return connectorResponse.statusCode() == HttpURLConnection.HTTP_FORBIDDEN
+                && "0".equals(connectorResponse.header("X-RateLimit-Remaining"));
+    }
+
+    /**
+     * Called when the library encounters HTTP error indicating that the API rate limit has been exceeded.
+     *
+     * <p>
+     * Any exception thrown from this method will cause the request to fail, and the caller of github-api will receive
+     * an exception. If this method returns normally, another request will be attempted. For that to make sense, the
+     * implementation needs to wait for some time.
+     *
+     * @param connectorResponse
+     *            Response information for this request.
+     *
+     * @throws IOException
+     *             the io exception
+     * @see <a href="https://developer.github.com/v3/#rate-limiting">API documentation from GitHub</a>
+     */
+    public abstract void onError(@Nonnull GitHubConnectorResponse connectorResponse) throws IOException;
+}

--- a/src/main/java/org/kohsuke/github/GitHubResponse.java
+++ b/src/main/java/org/kohsuke/github/GitHubResponse.java
@@ -7,6 +7,7 @@ import org.apache.commons.io.IOUtils;
 import org.kohsuke.github.connector.GitHubConnectorResponse;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.reflect.Array;
 import java.net.HttpURLConnection;
@@ -126,9 +127,26 @@ class GitHubResponse<T> {
      */
     @Nonnull
     static String getBodyAsString(GitHubConnectorResponse connectorResponse) throws IOException {
-        InputStreamReader r = null;
-        r = new InputStreamReader(connectorResponse.bodyStream(), StandardCharsets.UTF_8);
-        return IOUtils.toString(r);
+        InputStream inputStream = connectorResponse.bodyStream();
+        try (InputStreamReader r = new InputStreamReader(inputStream, StandardCharsets.UTF_8)) {
+            return IOUtils.toString(r);
+        }
+    }
+
+    /**
+     * Gets the body of the response as a {@link String}.
+     *
+     * @return the body of the response as a {@link String}.
+     * @throws IOException
+     *             if an I/O Exception occurs.
+     * @param connectorResponse
+     */
+    static String getBodyAsStringOrNull(GitHubConnectorResponse connectorResponse) {
+        try {
+            return getBodyAsString(connectorResponse);
+        } catch (NullPointerException | IOException e) {
+        }
+        return null;
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/HttpException.java
+++ b/src/main/java/org/kohsuke/github/HttpException.java
@@ -1,5 +1,7 @@
 package org.kohsuke.github;
 
+import org.kohsuke.github.connector.GitHubConnectorResponse;
+
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -104,6 +106,20 @@ public class HttpException extends GHIOException {
      */
     public HttpException(int responseCode, String responseMessage, @CheckForNull URL url, Throwable cause) {
         this(responseCode, responseMessage, url == null ? null : url.toString(), cause);
+    }
+
+    /**
+     * Instantiates a new Http exception.
+     *
+     * @param connectorResponse
+     *            the connector response to base this on
+     */
+    public HttpException(GitHubConnectorResponse connectorResponse) {
+        this(GitHubResponse.getBodyAsStringOrNull(connectorResponse),
+                connectorResponse.statusCode(),
+                connectorResponse.header("Status"),
+                connectorResponse.request().url().toString());
+        this.responseHeaderFields = connectorResponse.allHeaders();
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/RateLimitHandler.java
+++ b/src/main/java/org/kohsuke/github/RateLimitHandler.java
@@ -12,10 +12,12 @@ import javax.annotation.Nonnull;
  * Pluggable strategy to determine what to do when the API rate limit is reached.
  *
  * @author Kohsuke Kawaguchi
- * @see GitHubBuilder#withRateLimitHandler(RateLimitHandler) GitHubBuilder#withRateLimitHandler(RateLimitHandler)
+ * @see GitHubBuilder#withRateLimitHandler(GitHubRateLimitHandler)
+ *      GitHubBuilder#withRateLimitHandler(GitHubRateLimitHandler)
  * @see AbuseLimitHandler
  */
-public abstract class RateLimitHandler {
+@Deprecated
+public abstract class RateLimitHandler extends GitHubRateLimitHandler {
 
     /**
      * Called when the library encounters HTTP error indicating that the API rate limit has been exceeded.
@@ -33,7 +35,7 @@ public abstract class RateLimitHandler {
      * @see <a href="https://developer.github.com/v3/#rate-limiting">API documentation from GitHub</a>
      */
     public void onError(@Nonnull GitHubConnectorResponse connectorResponse) throws IOException {
-        GHIOException e = new HttpException("Rate limit violation",
+        GHIOException e = new HttpException("API rate limit reached",
                 connectorResponse.statusCode(),
                 connectorResponse.header("Status"),
                 connectorResponse.request().url().toString()).withResponseHeaderFields(connectorResponse.allHeaders());
@@ -58,12 +60,12 @@ public abstract class RateLimitHandler {
      * @see <a href="https://developer.github.com/v3/#rate-limiting">API documentation from GitHub</a>
      */
     @Deprecated
-    public void onError(IOException e, HttpURLConnection uc) throws IOException {
-    }
+    public abstract void onError(IOException e, HttpURLConnection uc) throws IOException;
 
     /**
      * Block until the API rate limit is reset. Useful for long-running batch processing.
      */
+    @Deprecated
     public static final RateLimitHandler WAIT = new RateLimitHandler() {
         @Override
         public void onError(IOException e, HttpURLConnection uc) throws IOException {
@@ -86,10 +88,11 @@ public abstract class RateLimitHandler {
     /**
      * Fail immediately.
      */
+    @Deprecated
     public static final RateLimitHandler FAIL = new RateLimitHandler() {
         @Override
         public void onError(IOException e, HttpURLConnection uc) throws IOException {
-            throw (IOException) new IOException("API rate limit reached").initCause(e);
+            throw e;
         }
     };
 }

--- a/src/main/java/org/kohsuke/github/connector/GitHubConnectorResponse.java
+++ b/src/main/java/org/kohsuke/github/connector/GitHubConnectorResponse.java
@@ -48,6 +48,7 @@ public abstract class GitHubConnectorResponse implements Closeable {
      * Get this response as a {@link HttpURLConnection}.
      *
      * @return an object that implements at least the response related methods of {@link HttpURLConnection}.
+     * @deprecated This method is present only to provide backward compatibility with other deprecated components.
      */
     @Deprecated
     @Nonnull
@@ -81,13 +82,6 @@ public abstract class GitHubConnectorResponse implements Closeable {
      *             if an I/O Exception occurs.
      */
     public abstract InputStream bodyStream() throws IOException;
-
-    /**
-     * The error message for this response.
-     *
-     * @return if there is an error with some error string, that is returned. If not, {@code null}.
-     */
-    public abstract String errorMessage();
 
     /**
      * Gets the {@link GitHubConnectorRequest} for this response.

--- a/src/main/java/org/kohsuke/github/connector/GitHubConnectorResponse.java
+++ b/src/main/java/org/kohsuke/github/connector/GitHubConnectorResponse.java
@@ -113,4 +113,25 @@ public abstract class GitHubConnectorResponse implements Closeable {
         return headers;
     }
 
+    /**
+     * Unwraps a {@link GitHubConnectorResponse} from a {@link HttpURLConnection} adapter.
+     *
+     * Only works on the internal {@link GitHubConnectorResponseHttpUrlConnectionAdapter}.
+     *
+     * @param connection
+     *            the connection to unwrap.
+     * @return an unwrapped response from an adapter.
+     * @throws UnsupportedOperationException
+     *             if the connection is not an adapter.
+     * @deprecated Only preset for testing and interaction with deprecated HttpURLConnection components.
+     */
+    @Deprecated
+    public final static GitHubConnectorResponse fromHttpURLConnectionAdapter(HttpURLConnection connection) {
+        if (connection instanceof GitHubConnectorResponseHttpUrlConnectionAdapter) {
+            return ((GitHubConnectorResponseHttpUrlConnectionAdapter) connection).connectorResponse();
+        } else {
+            throw new UnsupportedOperationException(
+                    "Cannot unwrap GitHubConnectorResponse from " + connection.getClass().getName());
+        }
+    }
 }

--- a/src/main/java/org/kohsuke/github/connector/GitHubConnectorResponseHttpUrlConnectionAdapter.java
+++ b/src/main/java/org/kohsuke/github/connector/GitHubConnectorResponseHttpUrlConnectionAdapter.java
@@ -9,6 +9,14 @@ import java.net.HttpURLConnection;
 import java.security.Permission;
 import java.util.*;
 
+/**
+ * Adapter class for {@link org.kohsuke.github.connector.GitHubConnectorResponse} to be usable as a
+ * {@link HttpURLConnection}.
+ *
+ * Behavior is equivalent to a {@link HttpURLConnection} after {@link HttpURLConnection#connect()} has been called.
+ * Methods that make no sense throw {@link UnsupportedOperationException}.
+ */
+@Deprecated
 class GitHubConnectorResponseHttpUrlConnectionAdapter extends HttpURLConnection {
 
     private final GitHubConnectorResponse connectorResponse;
@@ -17,6 +25,16 @@ class GitHubConnectorResponseHttpUrlConnectionAdapter extends HttpURLConnection 
         super(connectorResponse.request().url());
         this.connected = true;
         this.connectorResponse = connectorResponse;
+    }
+
+    /**
+     * Readable to support {@link GitHubConnectorResponse#fromHttpURLConnectionAdapter(HttpURLConnection)} which only
+     * exist for testing.
+     *
+     * @return
+     */
+    GitHubConnectorResponse connectorResponse() {
+        return connectorResponse;
     }
 
     @Override

--- a/src/main/java/org/kohsuke/github/extras/okhttp3/OkHttpGitHubConnector.java
+++ b/src/main/java/org/kohsuke/github/extras/okhttp3/OkHttpGitHubConnector.java
@@ -8,10 +8,8 @@ import org.kohsuke.github.connector.GitHubConnectorRequest;
 import org.kohsuke.github.connector.GitHubConnectorResponse;
 
 import java.io.ByteArrayInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -20,10 +18,6 @@ import java.util.logging.Logger;
 import java.util.zip.GZIPInputStream;
 
 import javax.annotation.Nonnull;
-
-import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
-import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
-import static java.util.logging.Level.FINER;
 
 /**
  * {@link HttpConnector} for {@link OkHttpClient}.
@@ -129,17 +123,6 @@ public class OkHttpGitHubConnector implements GitHubConnector {
          * {@inheritDoc}
          */
         public InputStream bodyStream() throws IOException {
-            if (response.code() >= HTTP_BAD_REQUEST) {
-                if (response.code() == HTTP_NOT_FOUND) {
-                    throw new FileNotFoundException(request().url().toString());
-                } else {
-                    throw new HttpException(errorMessage(),
-                            response.code(),
-                            response.message(),
-                            request().url().toString());
-                }
-            }
-
             readBodyBytes();
             InputStream stream = bodyBytes == null ? null : new ByteArrayInputStream(bodyBytes);
             return stream;
@@ -159,24 +142,7 @@ public class OkHttpGitHubConnector implements GitHubConnector {
                     }
                     bodyBytesRead = true;
                 }
-
             }
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        public String errorMessage() {
-            String result = null;
-            try {
-                if (!response.isSuccessful()) {
-                    readBodyBytes();
-                    result = bodyBytes == null ? null : new String(bodyBytes, StandardCharsets.UTF_8);
-                }
-            } catch (Exception e) {
-                LOGGER.log(FINER, "Ignored exception get error message", e);
-            }
-            return result;
         }
 
         /**

--- a/src/main/java/org/kohsuke/github/internal/GitHubConnectorHttpConnectorAdapter.java
+++ b/src/main/java/org/kohsuke/github/internal/GitHubConnectorHttpConnectorAdapter.java
@@ -193,6 +193,9 @@ public final class GitHubConnectorHttpConnectorAdapter implements GitHubConnecto
             return inputBytes == null ? null : new ByteArrayInputStream(inputBytes);
         }
 
+        /**
+         * {@inheritDoc}
+         */
         @SuppressFBWarnings(value = { "EI_EXPOSE_REP" },
                 justification = "Internal implementation class. Should not be used externally.")
         @Nonnull

--- a/src/main/java/org/kohsuke/github/internal/GitHubConnectorHttpConnectorAdapter.java
+++ b/src/main/java/org/kohsuke/github/internal/GitHubConnectorHttpConnectorAdapter.java
@@ -8,14 +8,12 @@ import org.kohsuke.github.connector.GitHubConnectorRequest;
 import org.kohsuke.github.connector.GitHubConnectorResponse;
 
 import java.io.ByteArrayInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.net.HttpURLConnection;
 import java.net.ProtocolException;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
@@ -23,8 +21,6 @@ import java.util.zip.GZIPInputStream;
 
 import javax.annotation.Nonnull;
 
-import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
-import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.util.logging.Level.*;
 
 /**
@@ -163,8 +159,6 @@ public final class GitHubConnectorHttpConnectorAdapter implements GitHubConnecto
 
         private boolean inputStreamRead = false;
         private byte[] inputBytes = null;
-        private boolean errorStreamRead = false;
-        private String errorString = null;
 
         @Nonnull
         private final HttpURLConnection connection;
@@ -181,20 +175,13 @@ public final class GitHubConnectorHttpConnectorAdapter implements GitHubConnecto
          * {@inheritDoc}
          */
         public InputStream bodyStream() throws IOException {
-            if (connection.getResponseCode() >= HTTP_BAD_REQUEST) {
-                if (connection.getResponseCode() == HTTP_NOT_FOUND) {
-                    throw new FileNotFoundException(request().url().toString());
-                } else {
-                    throw new HttpException(errorMessage(),
-                            connection.getResponseCode(),
-                            connection.getResponseMessage(),
-                            connection.getURL().toString());
-                }
-            }
-
             synchronized (this) {
                 if (!inputStreamRead) {
-                    try (InputStream stream = wrapStream(connection.getInputStream())) {
+                    InputStream rawStream = connection.getErrorStream();
+                    if (rawStream == null) {
+                        rawStream = connection.getInputStream();
+                    }
+                    try (InputStream stream = wrapStream(rawStream)) {
                         if (stream != null) {
                             inputBytes = IOUtils.toByteArray(stream);
                         }
@@ -204,31 +191,6 @@ public final class GitHubConnectorHttpConnectorAdapter implements GitHubConnecto
             }
 
             return inputBytes == null ? null : new ByteArrayInputStream(inputBytes);
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        public String errorMessage() {
-            String result = null;
-            try {
-                synchronized (this) {
-                    if (!errorStreamRead) {
-                        try (InputStream stream = wrapStream(connection.getErrorStream())) {
-                            if (stream != null) {
-                                errorString = new String(IOUtils.toByteArray(stream), StandardCharsets.UTF_8);
-                            }
-                        }
-                        errorStreamRead = true;
-                    }
-                }
-                if (errorString != null) {
-                    result = errorString;
-                }
-            } catch (Exception e) {
-                LOGGER.log(FINER, "Ignored exception get error message", e);
-            }
-            return result;
         }
 
         @SuppressFBWarnings(value = { "EI_EXPOSE_REP" },

--- a/src/test/java/org/kohsuke/github/AbuseLimitHandlerTest.java
+++ b/src/test/java/org/kohsuke/github/AbuseLimitHandlerTest.java
@@ -176,8 +176,8 @@ public class AbuseLimitHandlerTest extends AbstractGitHubWireMockTest {
             getTempRepository();
             fail();
         } catch (Exception e) {
-            assertThat(e, instanceOf(IOException.class));
-            assertThat(e.getCause(), instanceOf(HttpException.class));
+            assertThat(e, instanceOf(HttpException.class));
+            assertThat(e.getMessage(), equalTo("Abuse limit reached"));
         }
 
         assertThat(mockGitHub.getRequestCount(), equalTo(2));
@@ -203,8 +203,8 @@ public class AbuseLimitHandlerTest extends AbstractGitHubWireMockTest {
 
             fail();
         } catch (Exception e) {
-            assertThat(e, instanceOf(IOException.class));
-            assertThat(e.getCause(), instanceOf(HttpException.class));
+            assertThat(e, instanceOf(HttpException.class));
+            assertThat(e.getMessage(), equalTo("Abuse limit reached"));
         }
 
         assertThat(mockGitHub.getRequestCount(), equalTo(2));

--- a/src/test/java/org/kohsuke/github/AbuseLimitHandlerTest.java
+++ b/src/test/java/org/kohsuke/github/AbuseLimitHandlerTest.java
@@ -5,6 +5,7 @@ import org.apache.commons.io.IOUtils;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Test;
+import org.kohsuke.github.connector.GitHubConnectorResponse;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -59,6 +60,13 @@ public class AbuseLimitHandlerTest extends AbstractGitHubWireMockTest {
                     @Override
                     public void onError(IOException e, HttpURLConnection uc) throws IOException {
 
+                        GitHubConnectorResponse connectorResponse = null;
+                        try {
+                            connectorResponse = GitHubConnectorResponse.fromHttpURLConnectionAdapter(uc);
+                        } catch (UnsupportedOperationException ex) {
+                            assertThat(ex.getMessage(), startsWith("Cannot unwrap GitHubConnectorResponse"));
+                        }
+
                         // Verify
                         assertThat(uc.getDate(), Matchers.greaterThanOrEqualTo(new Date().getTime() - 10000));
                         assertThat(uc.getExpiration(), equalTo(0L));
@@ -86,6 +94,12 @@ public class AbuseLimitHandlerTest extends AbstractGitHubWireMockTest {
                         assertThat(errorStream, notNullValue());
                         String error = IOUtils.toString(errorStream, StandardCharsets.UTF_8);
                         assertThat(error, containsString("Must have push access to repository"));
+
+                        if (connectorResponse != null) {
+                            String connectorBody = IOUtils.toString(connectorResponse.bodyStream(),
+                                    StandardCharsets.UTF_8);
+                            assertThat(connectorBody, containsString("Must have push access to repository"));
+                        }
 
                         // calling again should still error
                         ioEx = Assert.assertThrows(IOException.class, () -> uc.getInputStream());
@@ -116,12 +130,10 @@ public class AbuseLimitHandlerTest extends AbstractGitHubWireMockTest {
                         Assert.assertThrows(IllegalStateException.class, () -> uc.setRequestProperty("bogus", "thing"));
                         Assert.assertThrows(IllegalStateException.class, () -> uc.setUseCaches(true));
 
-                        boolean isAdapter = false;
-                        if (uc.toString().contains("GitHubConnectorResponseHttpUrlConnectionAdapter")) {
-                            isAdapter = true;
-                        }
+                        if (connectorResponse != null) {
+                            assertThat(uc.toString(),
+                                    containsString("GitHubConnectorResponseHttpUrlConnectionAdapter"));
 
-                        if (isAdapter) {
                             Assert.assertThrows(UnsupportedOperationException.class,
                                     () -> uc.getAllowUserInteraction());
                             Assert.assertThrows(UnsupportedOperationException.class, () -> uc.getConnectTimeout());

--- a/src/test/java/org/kohsuke/github/RateLimitHandlerTest.java
+++ b/src/test/java/org/kohsuke/github/RateLimitHandlerTest.java
@@ -56,8 +56,8 @@ public class RateLimitHandlerTest extends AbstractGitHubWireMockTest {
             getTempRepository();
             fail();
         } catch (Exception e) {
-            assertThat(e, instanceOf(IOException.class));
-            assertThat(e.getCause(), instanceOf(HttpException.class));
+            assertThat(e, instanceOf(HttpException.class));
+            assertThat(e.getMessage(), equalTo("API rate limit reached"));
         }
 
         assertThat(mockGitHub.getRequestCount(), equalTo(2));
@@ -83,8 +83,8 @@ public class RateLimitHandlerTest extends AbstractGitHubWireMockTest {
 
             fail();
         } catch (Exception e) {
-            assertThat(e, instanceOf(IOException.class));
-            assertThat(e.getCause(), instanceOf(HttpException.class));
+            assertThat(e, instanceOf(HttpException.class));
+            assertThat(e.getMessage(), equalTo("API rate limit reached"));
         }
 
         assertThat(mockGitHub.getRequestCount(), equalTo(2));


### PR DESCRIPTION
# Description

This change completes the deprecation of all classes and methods that use `HttpURLConnection`. 


# Before submitting a PR:
We love getting PRs, but we hate asking people for the same basic changes every time.

- [ ] Push your changes to a branch other than `main`. Create your PR from that branch.
- [ ] Add JavaDocs and other comments
- [ ] Write tests that run and pass in CI. See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to capture snapshot data.
- [ ] Run `mvn -D enable-ci clean install site` locally. If this command doesn't succeed, your change will not pass CI.

# When creating a PR: 

- [ ] Fill in the "Description" above.
- [ ] Enable "Allow edits from maintainers".
