### PR TITLE
Add support for GitHub event branch_protection_rule

### DIFF
--- a/src/main/java/org/kohsuke/github/GHEvent.java
+++ b/src/main/java/org/kohsuke/github/GHEvent.java
@@ -10,6 +10,7 @@ import java.util.Locale;
  * @see <a href="https://developer.github.com/v3/activity/events/types/">Event type reference</a>
  */
 public enum GHEvent {
+    BRANCH_PROTECTION_RULE,
     CHECK_RUN,
     CHECK_SUITE,
     CODE_SCANNING_ALERT,

--- a/src/test/java/org/kohsuke/github/EnumTest.java
+++ b/src/test/java/org/kohsuke/github/EnumTest.java
@@ -28,7 +28,7 @@ public class EnumTest extends AbstractGitHubWireMockTest {
 
         assertThat(GHDirection.values().length, equalTo(2));
 
-        assertThat(GHEvent.values().length, equalTo(62));
+        assertThat(GHEvent.values().length, equalTo(63));
         assertThat(GHEvent.ALL.symbol(), equalTo("*"));
         assertThat(GHEvent.PULL_REQUEST.symbol(), equalTo(GHEvent.PULL_REQUEST.toString().toLowerCase()));
 


### PR DESCRIPTION
# Description
Add support for GitHub event _branch_protection_rule_
Fixes #1297 
Note i had a first look at [GHEventPayload.java](https://github.com/hub4j/github-api/blob/main/src/main/java/org/kohsuke/github/GHEventPayload.java) but i don't know how to fully add the payload for this event (seems it also needs a new event class)

# Before submitting a PR:
We love getting PRs, but we hate asking people for the same basic changes every time.

- [X] Push your changes to a branch other than `main`. Create your PR from that branch.
- [ ] Add JavaDocs and other comments
- [X] Write tests that run and pass in CI. See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to capture snapshot data.
- [ ] Run `mvn -D enable-ci clean install site` locally. If this command doesn't succeed, your change will not pass CI.

# When creating a PR: 

- [X] Fill in the "Description" above.
- [X] Enable "Allow edits from maintainers".
