### PR TITLE
Fix for Add WEBHOOK_JOB to GHEvent

### DIFF
--- a/src/main/java/org/kohsuke/github/GHEvent.java
+++ b/src/main/java/org/kohsuke/github/GHEvent.java
@@ -69,6 +69,7 @@ public enum GHEvent {
     TEAM,
     TEAM_ADD,
     WATCH,
+    WEBHOOK_JOB,
     WORKFLOW_DISPATCH,
     WORKFLOW_RUN,
 

--- a/src/main/java/org/kohsuke/github/GHEvent.java
+++ b/src/main/java/org/kohsuke/github/GHEvent.java
@@ -69,7 +69,7 @@ public enum GHEvent {
     TEAM,
     TEAM_ADD,
     WATCH,
-    WEBHOOK_JOB,
+    WORKFLOW_JOB,
     WORKFLOW_DISPATCH,
     WORKFLOW_RUN,
 

--- a/src/test/java/org/kohsuke/github/EnumTest.java
+++ b/src/test/java/org/kohsuke/github/EnumTest.java
@@ -28,7 +28,7 @@ public class EnumTest extends AbstractGitHubWireMockTest {
 
         assertThat(GHDirection.values().length, equalTo(2));
 
-        assertThat(GHEvent.values().length, equalTo(63));
+        assertThat(GHEvent.values().length, equalTo(64));
         assertThat(GHEvent.ALL.symbol(), equalTo("*"));
         assertThat(GHEvent.PULL_REQUEST.symbol(), equalTo(GHEvent.PULL_REQUEST.toString().toLowerCase()));
 


### PR DESCRIPTION
# Description

Adding fix for https://github.com/hub4j/github-api/issues/1288 - new enum value for WORKFLOW_JOB in GHEvent.

Fixes #1288 

# Before submitting a PR:
We love getting PRs, but we hate asking people for the same basic changes every time.

- [ ] Push your changes to a branch other than `main`. Create your PR from that branch.
- [ ] Add JavaDocs and other comments
- [ ] Write tests that run and pass in CI. See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to capture snapshot data.
- [ ] Run `mvn -D enable-ci clean install site` locally. If this command doesn't succeed, your change will not pass CI.

# When creating a PR: 

- [ ] Fill in the "Description" above.
- [ ] Enable "Allow edits from maintainers".
