### PR TITLE
Add the node_id to the Discussion Category payload

### DIFF
--- a/src/main/java/org/kohsuke/github/GHRepositoryDiscussion.java
+++ b/src/main/java/org/kohsuke/github/GHRepositoryDiscussion.java
@@ -113,6 +113,7 @@ public class GHRepositoryDiscussion extends GHObject {
     public static class Category {
 
         private long id;
+        private String nodeId;
         private long repositoryId;
         private String emoji;
         private String name;
@@ -124,6 +125,10 @@ public class GHRepositoryDiscussion extends GHObject {
 
         public long getId() {
             return id;
+        }
+
+        public String getNodeId() {
+            return nodeId;
         }
 
         public long getRepositoryId() {

--- a/src/test/java/org/kohsuke/github/GHEventPayloadTest.java
+++ b/src/test/java/org/kohsuke/github/GHEventPayloadTest.java
@@ -953,6 +953,7 @@ public class GHEventPayloadTest extends AbstractGitHubWireMockTest {
         GHRepositoryDiscussion.Category category = discussion.getCategory();
 
         assertThat(category.getId(), is(33522033L));
+        assertThat(category.getNodeId(), is("DIC_kwDOEq3cwc4B_4Fx"));
         assertThat(category.getEmoji(), is(":pray:"));
         assertThat(category.getName(), is("Q&A"));
         assertThat(category.getDescription(), is("Ask the community for help"));
@@ -1000,6 +1001,7 @@ public class GHEventPayloadTest extends AbstractGitHubWireMockTest {
         GHRepositoryDiscussion.Category category = discussion.getCategory();
 
         assertThat(category.getId(), is(33522033L));
+        assertThat(category.getNodeId(), is("DIC_kwDOEq3cwc4B_4Fx"));
         assertThat(category.getEmoji(), is(":pray:"));
         assertThat(category.getName(), is("Q&A"));
         assertThat(category.getDescription(), is("Ask the community for help"));
@@ -1048,6 +1050,7 @@ public class GHEventPayloadTest extends AbstractGitHubWireMockTest {
         GHRepositoryDiscussion.Category category = discussion.getCategory();
 
         assertThat(category.getId(), is(33522033L));
+        assertThat(category.getNodeId(), is("DIC_kwDOEq3cwc4B_4Fx"));
         assertThat(category.getEmoji(), is(":pray:"));
         assertThat(category.getName(), is("Q&A"));
         assertThat(category.getDescription(), is("Ask the community for help"));

--- a/src/test/resources/org/kohsuke/github/GHEventPayloadTest/discussion_answered.json
+++ b/src/test/resources/org/kohsuke/github/GHEventPayloadTest/discussion_answered.json
@@ -4,6 +4,7 @@
         "repository_url": "https://api.github.com/repos/gsmet/quarkus-bot-java-playground",
         "category": {
             "id": 33522033,
+            "node_id": "DIC_kwDOEq3cwc4B_4Fx",
             "repository_id": 313384129,
             "emoji": ":pray:",
             "name": "Q&A",

--- a/src/test/resources/org/kohsuke/github/GHEventPayloadTest/discussion_created.json
+++ b/src/test/resources/org/kohsuke/github/GHEventPayloadTest/discussion_created.json
@@ -4,6 +4,7 @@
         "repository_url": "https://api.github.com/repos/gsmet/quarkus-bot-java-playground",
         "category": {
             "id": 33522033,
+            "node_id": "DIC_kwDOEq3cwc4B_4Fx",
             "repository_id": 313384129,
             "emoji": ":pray:",
             "name": "Q&A",

--- a/src/test/resources/org/kohsuke/github/GHEventPayloadTest/discussion_labeled.json
+++ b/src/test/resources/org/kohsuke/github/GHEventPayloadTest/discussion_labeled.json
@@ -4,6 +4,7 @@
         "repository_url": "https://api.github.com/repos/gsmet/quarkus-bot-java-playground",
         "category": {
             "id": 33522033,
+            "node_id": "DIC_kwDOEq3cwc4B_4Fx",
             "repository_id": 313384129,
             "emoji": ":pray:",
             "name": "Q&A",


### PR DESCRIPTION
I reported the fact that the field was missing to the GitHub team and
they were kind enough to add it so we can now take it into account.

The numeric id is not exposed at all in the GraphQL API and neither in the UI so if you want to reference an id, it's kinda problematic right now, you have to generate payloads and get the id from there.

With this addition, you will be able to reference the node_id which is present in the GraphQL API.