### PR TITLE
fix: fixed issue #1265

### DIFF
--- a/src/main/java/org/kohsuke/github/GHWorkflow.java
+++ b/src/main/java/org/kohsuke/github/GHWorkflow.java
@@ -124,6 +124,10 @@ public class GHWorkflow extends GHObject {
      *             the io exception
      */
     public void dispatch(String ref, Map<String, Object> inputs) throws IOException {
+        if (ref == null || ref.length() == 0) {
+            throw new GHIOException("ref is null or empty.");
+        }
+        
         Requester requester = root().createRequest()
                 .method("POST")
                 .withUrlPath(getApiRoute(), "dispatches")

--- a/src/main/java/org/kohsuke/github/GHWorkflow.java
+++ b/src/main/java/org/kohsuke/github/GHWorkflow.java
@@ -122,12 +122,14 @@ public class GHWorkflow extends GHObject {
      *            default properties configured in the workflow file will be used when inputs are omitted.
      * @throws IOException
      *             the io exception
+     * @throws IllegalArgumentException
+     *             the illegal argument exception
      */
-    public void dispatch(String ref, Map<String, Object> inputs) throws IOException {
+    public void dispatch(String ref, Map<String, Object> inputs) throws IOException, IllegalArgumentException {
         if (ref == null || ref.length() == 0) {
-            throw new GHIOException("ref is null or empty.");
+            throw new IllegalArgumentException("ref cannot be null or empty");
         }
-        
+
         Requester requester = root().createRequest()
                 .method("POST")
                 .withUrlPath(getApiRoute(), "dispatches")

--- a/src/test/java/org/kohsuke/github/GHWorkflowTest.java
+++ b/src/test/java/org/kohsuke/github/GHWorkflowTest.java
@@ -78,16 +78,16 @@ public class GHWorkflowTest extends AbstractGitHubWireMockTest {
     }
 
     @Test
-    public void testDispatch() throws IOException {
+    public void testDispatch() throws IOException, IllegalArgumentException {
         GHWorkflow workflow = repo.getWorkflow("test-workflow.yml");
 
-        String expectedMessage = "ref is null or empty.";
-        GHIOException nullException = assertThrows(GHIOException.class, () -> {
+        String expectedMessage = "ref cannot be null or empty";
+        IllegalArgumentException nullException = assertThrows(IllegalArgumentException.class, () -> {
             workflow.dispatch(null);
         });
         assertThat(nullException.getMessage(), equalTo(expectedMessage));
 
-        GHIOException emptyException = assertThrows(GHIOException.class, () -> {
+        IllegalArgumentException emptyException = assertThrows(IllegalArgumentException.class, () -> {
             workflow.dispatch("");
         });
         assertThat(emptyException.getMessage(), equalTo(expectedMessage));

--- a/src/test/java/org/kohsuke/github/GHWorkflowTest.java
+++ b/src/test/java/org/kohsuke/github/GHWorkflowTest.java
@@ -14,6 +14,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThrows;
 
 public class GHWorkflowTest extends AbstractGitHubWireMockTest {
 
@@ -79,6 +80,17 @@ public class GHWorkflowTest extends AbstractGitHubWireMockTest {
     @Test
     public void testDispatch() throws IOException {
         GHWorkflow workflow = repo.getWorkflow("test-workflow.yml");
+
+        String expectedMessage = "ref is null or empty.";
+        GHIOException nullException = assertThrows(GHIOException.class, () -> {
+            workflow.dispatch(null);
+        });
+        assertThat(nullException.getMessage(), equalTo(expectedMessage));
+
+        GHIOException emptyException = assertThrows(GHIOException.class, () -> {
+            workflow.dispatch("");
+        });
+        assertThat(emptyException.getMessage(), equalTo(expectedMessage));
 
         workflow.dispatch("main");
         verify(postRequestedFor(


### PR DESCRIPTION
# Description

Fixes issue #1265. 
- added null and empty check for 'ref' and throw IllegalArgumentException if null or empty is passed in. I'm not sure what would be the most appropriate type of exception to throw and would be very happy to change it if you see fits. 
- added tests to verify the issue is fixed

# Before submitting a PR:

- [ ] Changes must not break binary backwards compatibility. If you are unclear on how to make the change you think is needed while maintaining backward compatibility, [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [ ] Add JavaDocs and other comments as appropriate. Consider including links in comments to relevant documentation on https://docs.github.com/en/rest .  
- [x] Add tests that cover any added or changed code. This generally requires capturing snapshot test data. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [ ] Run `mvn -D enable-ci clean install site` locally. If this command doesn't succeed, your change will not pass CI.
- [x] Push your changes to a branch other than `main`. You will create your PR from that branch.

# When creating a PR: 

- [ ] Fill in the "Description" above with clear summary of the changes. This includes:
  - [x] If this PR fixes one or more issues, include "Fixes #<issue number>" lines for each issue. 
  - [ ] Provide links to relevant documentation on https://docs.github.com/en/rest where possible.
- [ ] All lines of new code should be covered by tests as reported by code coverage. Any lines that are not covered must have PR comments explaining why they cannot be covered. For example, "Reaching this particular exception is hard and is not a particular common scenario."
- [x] Enable "Allow edits from maintainers".
