### PR TITLE
Added runAttempt and runStartedAt attributes to the GHWorkflowRun.java

### DIFF
--- a/src/main/java/org/kohsuke/github/GHWorkflowRun.java
+++ b/src/main/java/org/kohsuke/github/GHWorkflowRun.java
@@ -32,6 +32,9 @@ public class GHWorkflowRun extends GHObject {
     private long runNumber;
     private long workflowId;
 
+    private long runAttempt;
+    private String runStartedAt;
+
     private String htmlUrl;
     private String jobsUrl;
     private String logsUrl;
@@ -77,6 +80,26 @@ public class GHWorkflowRun extends GHObject {
      */
     public long getWorkflowId() {
         return workflowId;
+    }
+
+    /**
+     * The run attempt.
+     *
+     * @return the run attempt
+     */
+    public long getRunAttempt() {
+        return runAttempt;
+    }
+
+    /**
+     * When was this run triggered?
+     *
+     * @return run triggered
+     * @throws IOException
+     *             on error
+     */
+    public Date getRunStartedAt() throws IOException {
+        return GitHubClient.parseDate(runStartedAt);
     }
 
     @Override

--- a/src/test/java/org/kohsuke/github/GHEventPayloadTest.java
+++ b/src/test/java/org/kohsuke/github/GHEventPayloadTest.java
@@ -851,6 +851,8 @@ public class GHEventPayloadTest extends AbstractGitHubWireMockTest {
                 is("https://api.github.com/repos/gsmet/quarkus-bot-java-playground/actions/workflows/7087581"));
         assertThat(workflowRun.getCreatedAt().getTime(), is(1616524526000L));
         assertThat(workflowRun.getUpdatedAt().getTime(), is(1616524543000L));
+        assertThat(workflowRun.getRunAttempt(), is(1L));
+        assertThat(workflowRun.getRunStartedAt().getTime(), is(1616524526000L));
         assertThat(workflowRun.getHeadCommit().getId(), is("dbea8d8b6ed2cf764dfd84a215f3f9040b3d4423"));
         assertThat(workflowRun.getHeadCommit().getTreeId(), is("b17089e6a2574ec1002566fe980923e62dce3026"));
         assertThat(workflowRun.getHeadCommit().getMessage(), is("Update main.yml"));

--- a/src/test/resources/org/kohsuke/github/GHEventPayloadTest/workflow_run.json
+++ b/src/test/resources/org/kohsuke/github/GHEventPayloadTest/workflow_run.json
@@ -18,6 +18,8 @@
     "pull_requests": [],
     "created_at": "2021-03-23T18:35:26Z",
     "updated_at": "2021-03-23T18:35:43Z",
+    "run_attempt": 1,
+    "run_started_at": "2021-03-23T18:35:26Z",
     "jobs_url": "https://api.github.com/repos/gsmet/quarkus-bot-java-playground/actions/runs/680604745/jobs",
     "logs_url": "https://api.github.com/repos/gsmet/quarkus-bot-java-playground/actions/runs/680604745/logs",
     "check_suite_url": "https://api.github.com/repos/gsmet/quarkus-bot-java-playground/check-suites/2327154397",


### PR DESCRIPTION
# Description

I added the runAttempt and runStartedAt fields in the link below to the WorkflowRun class.
https://docs.github.com/en/rest/reference/actions#list-workflow-runs-for-a-repository
# Before submitting a PR:

- [x] Changes must not break binary backwards compatibility. If you are unclear on how to make the change you think is needed while maintaining backward compatibility, [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [X] Add JavaDocs and other comments as appropriate. Consider including links in comments to relevant documentation on https://docs.github.com/en/rest .  
- [x] Add tests that cover any added or changed code. This generally requires capturing snapshot test data. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [X] Run `mvn -D enable-ci clean install site` locally. If this command doesn't succeed, your change will not pass CI.
- [X] Push your changes to a branch other than `main`. You will create your PR from that branch.

# When creating a PR: 

- [X] Fill in the "Description" above with clear summary of the changes. This includes:
  - [ ] If this PR fixes one or more issues, include "Fixes #<issue number>" lines for each issue. 
  - [X] Provide links to relevant documentation on https://docs.github.com/en/rest where possible.
- [X] All lines of new code should be covered by tests as reported by code coverage. Any lines that are not covered must have PR comments explaining why they cannot be covered. For example, "Reaching this particular exception is hard and is not a particular common scenario."
- [X] Enable "Allow edits from maintainers".
