### PR TITLE
Fix deadlock in getCommit

### DIFF
--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -113,11 +113,11 @@ public class GHRepository extends GHObject {
 
     private String pushed_at;
 
-    private Map<Integer, GHMilestone> milestones = new WeakHashMap<Integer, GHMilestone>();
+    private Map<Integer, GHMilestone> milestones = Collections.synchronizedMap(new WeakHashMap<>());
 
     private String default_branch, language;
 
-    private Map<String, GHCommit> commits = new WeakHashMap<String, GHCommit>();
+    private Map<String, GHCommit> commits = Collections.synchronizedMap(new WeakHashMap<>());
 
     @SkipFromToString
     private GHRepoPermission permissions;


### PR DESCRIPTION
# Description

We are seeing infrequent deadlocks using the `GHRepository::getCommit` from a threadpool.
 
thread dump snippet
```
 #17072 daemon prio=5 os_prio=0 cpu=943046.99ms elapsed=8709.52s tid=0x00007f3ca82a5fb0 nid=0x8de9 runnable [0x00007f3903353000] java.lang.Thread.State: RUNNABLE at java.util.WeakHashMap.get(java.base@11.0.5/WeakHashMap.java:404) at org.kohsuke.github.GHRepository.getCommit(GHRepository.java:1627) at
```

WeakHashMap is not threadsafe, and using  `Collections.synchronisedMap` is the [recommended way](https://docs.oracle.com/javase/7/docs/api/java/util/WeakHashMap.html) of making it so if this client should be usable concurrently?

# Before submitting a PR:

- [ ] Changes must not break binary backwards compatibility. If you are unclear on how to make the change you think is needed while maintaining backward compatibility, [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [ ] Add JavaDocs and other comments as appropriate. Consider including links in comments to relevant documentation on https://docs.github.com/en/rest .  
- [ ] Add tests that cover any added or changed code. This generally requires capturing snapshot test data. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [ ] Run `mvn -D enable-ci clean install site` locally. If this command doesn't succeed, your change will not pass CI.
- [ ] Push your changes to a branch other than `main`. You will create your PR from that branch.

# When creating a PR: 

- [ ] Fill in the "Description" above with clear summary of the changes. This includes:
  - [ ] If this PR fixes one or more issues, include "Fixes #<issue number>" lines for each issue. 
  - [ ] Provide links to relevant documentation on https://docs.github.com/en/rest where possible.
- [ ] All lines of new code should be covered by tests as reported by code coverage. Any lines that are not covered must have PR comments explaining why they cannot be covered. For example, "Reaching this particular exception is hard and is not a particular common scenario."
- [ ] Enable "Allow edits from maintainers".
