### PR TITLE
Use https in example GitHub Enterprise URL in Javadocs

### DIFF
--- a/src/main/java/org/kohsuke/github/GitHubBuilder.java
+++ b/src/main/java/org/kohsuke/github/GitHubBuilder.java
@@ -243,7 +243,7 @@ public class GitHubBuilder implements Cloneable {
      *
      * @param endpoint
      *            The URL of GitHub (or GitHub enterprise) API endpoint, such as "https://api.github.com" or
-     *            "http://ghe.acme.com/api/v3". Note that GitHub Enterprise has <code>/api/v3</code> in the URL. For
+     *            "https://ghe.acme.com/api/v3". Note that GitHub Enterprise has <code>/api/v3</code> in the URL. For
      *            historical reasons, this parameter still accepts the bare domain name, but that's considered
      *            deprecated.
      * @return the git hub builder


### PR DESCRIPTION
I just spent a few hours banging my head against some mysterious errors that were resolved by using an https-based URL instead of an http one. I had copied from the Javadocs example URL and replaced the domain name, and did not notice that it started with `http:`.

Use `https:` in the example instead, as that is more likely what people want.

# Description

In the Javadocs for `GitHubBuilder.withEndpoint`, edit the example URL for GitHub Enterprise to use `https:` rather than `http:`.

# Before submitting a PR:

- [x] Changes must not break binary backwards compatibility. If you are unclear on how to make the change you think is needed while maintaining backward compatibility, [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [x] Add JavaDocs and other comments as appropriate. Consider including links in comments to relevant documentation on https://docs.github.com/en/rest .  
- [x] Add tests that cover any added or changed code. This generally requires capturing snapshot test data. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [x] Run `mvn -D enable-ci clean install site` locally. If this command doesn't succeed, your change will not pass CI.
- [x] Push your changes to a branch other than `main`. You will create your PR from that branch.

# When creating a PR: 

- [x] Fill in the "Description" above with clear summary of the changes. This includes:
  - [x] If this PR fixes one or more issues, include "Fixes #<issue number>" lines for each issue. 
  - [x] Provide links to relevant documentation on https://docs.github.com/en/rest where possible.
- [x] All lines of new code should be covered by tests as reported by code coverage. Any lines that are not covered must have PR comments explaining why they cannot be covered. For example, "Reaching this particular exception is hard and is not a particular common scenario."
- [x] Enable "Allow edits from maintainers".
