### PR TITLE
Target Java 8 in maven-javadoc-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>3.4.1</version>
           <configuration>
-            <source>11</source>
+            <release>8</release>
             <failOnWarnings>true</failOnWarnings>
             <doclint>all</doclint>
           </configuration>


### PR DESCRIPTION
To avoid errors related to modules.

Fixes #1528

It only makes sense, since the library itself targets Java 8 anyway, and the library's javadoc already links to JDK 8's javadoc (not JDK 11's).

The resulting javadoc does not seem to differ in any significant way; below is the result of a diff between the output with:

* maven-javadoc-plugin 3.0.0 + `<source>11</source>`
* maven-javadoc-plugin 3.4.1 + `<release>8</release>`

```
$ diff -I "Generated by javadoc" -r target/apidocs/ ~/tmp/github-api-apidocs-8
Binary files target/apidocs/member-search-index.zip and /home/yrodiere/tmp/github-api-apidocs-8/member-search-index.zip differ
diff -I 'Generated by javadoc' -r target/apidocs/org/kohsuke/github/GHPersonSet.html /home/yrodiere/tmp/github-api-apidocs-8/org/kohsuke/github/GHPersonSet.html
276c276
< <code><a href="https://docs.oracle.com/javase/8/docs/api/java/util/Collection.html?is-external=true#parallelStream()" title="class or interface in java.util" class="externalLink">parallelStream</a>, <a href="https://docs.oracle.com/javase/8/docs/api/java/util/Collection.html?is-external=true#removeIf(java.util.function.Predicate)" title="class or interface in java.util" class="externalLink">removeIf</a>, <a href="https://docs.oracle.com/javase/8/docs/api/java/util/Collection.html?is-external=true#stream()" title="class or interface in java.util" class="externalLink">stream</a>, <a href="https://docs.oracle.com/javase/8/docs/api/java/util/Collection.html?is-external=true#toArray(java.util.function.IntFunction)" title="class or interface in java.util" class="externalLink">toArray</a></code></li>
---
> <code><a href="https://docs.oracle.com/javase/8/docs/api/java/util/Collection.html?is-external=true#parallelStream()" title="class or interface in java.util" class="externalLink">parallelStream</a>, <a href="https://docs.oracle.com/javase/8/docs/api/java/util/Collection.html?is-external=true#removeIf(java.util.function.Predicate)" title="class or interface in java.util" class="externalLink">removeIf</a>, <a href="https://docs.oracle.com/javase/8/docs/api/java/util/Collection.html?is-external=true#stream()" title="class or interface in java.util" class="externalLink">stream</a></code></li>
Binary files target/apidocs/package-search-index.zip and /home/yrodiere/tmp/github-api-apidocs-8/package-search-index.zip differ
Binary files target/apidocs/type-search-index.zip and /home/yrodiere/tmp/github-api-apidocs-8/type-search-index.zip differ
```

Now, you will ask: what about when we drop support for JDK 8? Well, I don't have an answer for that, but I hope the problematic dependencies (those with split packages) will be gone by then. If not, I'd say that's a problem for another day.