### PR TITLE
feat: Add head_commit to GHEventPayload.Push

### DIFF
--- a/src/main/java/org/kohsuke/github/GHEventPayload.java
+++ b/src/main/java/org/kohsuke/github/GHEventPayload.java
@@ -1043,6 +1043,7 @@ public abstract class GHEventPayload extends GitHubInteractiveObject {
         private String ref;
         private int size;
         private List<PushCommit> commits;
+        private PushCommit headCommit;
         private Pusher pusher;
         private String compare;
 
@@ -1122,6 +1123,16 @@ public abstract class GHEventPayload extends GitHubInteractiveObject {
          */
         public List<PushCommit> getCommits() {
             return Collections.unmodifiableList(commits);
+        }
+
+        /**
+         * The head commit of the push.
+         *
+         * @return the commit
+         */
+        @SuppressFBWarnings(value = { "EI_EXPOSE_REP" }, justification = "Expected")
+        public PushCommit getHeadCommit() {
+            return headCommit;
         }
 
         /**

--- a/src/test/java/org/kohsuke/github/GHEventPayloadTest.java
+++ b/src/test/java/org/kohsuke/github/GHEventPayloadTest.java
@@ -624,6 +624,18 @@ public class GHEventPayloadTest extends AbstractGitHubWireMockTest {
         assertThat(event.getCommits().get(0).getRemoved().size(), is(0));
         assertThat(event.getCommits().get(0).getModified().size(), is(1));
         assertThat(event.getCommits().get(0).getModified().get(0), is("README.md"));
+
+        assertThat(event.getHeadCommit().getSha(), is("0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c"));
+        assertThat(event.getHeadCommit().getAuthor().getEmail(), is("baxterthehacker@users.noreply.github.com"));
+        assertThat(event.getHeadCommit().getAuthor().getUsername(), is("baxterthehacker"));
+        assertThat(event.getHeadCommit().getCommitter().getEmail(), is("baxterthehacker@users.noreply.github.com"));
+        assertThat(event.getHeadCommit().getCommitter().getUsername(), is("baxterthehacker"));
+        assertThat(event.getHeadCommit().getAdded().size(), is(0));
+        assertThat(event.getHeadCommit().getRemoved().size(), is(0));
+        assertThat(event.getHeadCommit().getModified().size(), is(1));
+        assertThat(event.getHeadCommit().getModified().get(0), is("README.md"));
+        assertThat(event.getHeadCommit().getMessage(), is("Update README.md"));
+
         SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
         formatter.setTimeZone(TimeZone.getTimeZone("UTC"));
         assertThat(formatter.format(event.getCommits().get(0).getTimestamp()), is("2015-05-05T23:40:15Z"));


### PR DESCRIPTION
When that class represents a commit being pushed to a branch, the list of commits is available and useful to know what was pushed.

When it represents a tag being pushed, the list of commits can be empty. The `head_commit` comes in handy to know more about the commit.

This change exposes `head_commit` using the getter `getHeadCommit()`.

The test data already has the data for this to work. The test case has been updated to test for this method.

The docs for this can be found at https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#push

Fixes: #1585

# Description

<!-- Describe your change here -->

# Before submitting a PR:

- [x] Changes must not break binary backwards compatibility. If you are unclear on how to make the change you think is needed while maintaining backward compatibility, [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [x] Add JavaDocs and other comments as appropriate. Consider including links in comments to relevant documentation on https://docs.github.com/en/rest .  
- [x] Add tests that cover any added or changed code. This generally requires capturing snapshot test data. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [ ] Run `mvn -D enable-ci clean install site` locally. If this command doesn't succeed, your change will not pass CI.
- [x] Push your changes to a branch other than `main`. You will create your PR from that branch.

# When creating a PR: 

- [x] Fill in the "Description" above with clear summary of the changes. This includes:
  - [x] If this PR fixes one or more issues, include "Fixes #<issue number>" lines for each issue. 
  - [x] Provide links to relevant documentation on https://docs.github.com/en/rest where possible.
- [x] All lines of new code should be covered by tests as reported by code coverage. Any lines that are not covered must have PR comments explaining why they cannot be covered. For example, "Reaching this particular exception is hard and is not a particular common scenario."
- [x] Enable "Allow edits from maintainers".
