### PR TITLE
Add logs in GitHubClient response. fixes #1594

### DIFF
--- a/src/main/java/org/kohsuke/github/GitHubClient.java
+++ b/src/main/java/org/kohsuke/github/GitHubClient.java
@@ -430,6 +430,7 @@ class GitHubClient {
                 logRequest(connectorRequest);
                 rateLimitChecker.checkRateLimit(this, request.rateLimitTarget());
                 connectorResponse = connector.send(connectorRequest);
+                logResponse(connectorResponse);
                 noteRateLimit(request.rateLimitTarget(), connectorResponse);
                 detectKnownErrors(connectorResponse, request, handler != null);
                 return createResponse(connectorResponse, handler);
@@ -520,8 +521,23 @@ class GitHubClient {
 
     private void logRequest(@Nonnull final GitHubConnectorRequest request) {
         LOGGER.log(FINE,
-                () -> "GitHub API request [" + (getLogin() == null ? "anonymous" : getLogin()) + "]: "
-                        + request.method() + " " + request.url().toString());
+                () -> String.format("(%s) GitHub API request [%s]: %s",
+                        Integer.toHexString(request.hashCode()),
+                        (getLogin() == null ? "anonymous" : getLogin()),
+                        (request.method() + " " + request.url().toString())));
+    }
+
+    private void logResponse(@Nonnull final GitHubConnectorResponse response) {
+        LOGGER.log(FINE, () -> {
+            try {
+                return String.format("(%s) GitHub API response [%s]: %s",
+                        Integer.toHexString(response.request().hashCode()),
+                        (getLogin() == null ? "anonymous" : getLogin()),
+                        (response.statusCode() + " " + GitHubResponse.getBodyAsString(response)));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
     }
 
     @Nonnull


### PR DESCRIPTION
# Description

This PR adds a log in order to debug the GitHub response.
I add the hash of the request to the begginning of the log, in order to identify which response corresponds to which request.