### PR TITLE
Fix unit of marketPlace plans

### DIFF
--- a/src/main/java/org/kohsuke/github/GHMarketplacePriceModel.java
+++ b/src/main/java/org/kohsuke/github/GHMarketplacePriceModel.java
@@ -12,11 +12,11 @@ import com.fasterxml.jackson.annotation.JsonValue;
 public enum GHMarketplacePriceModel {
 
     /** The free. */
-    FREE("free"),
+    FREE("FREE"),
     /** The per unit. */
-    PER_UNIT("per-unit"),
+    PER_UNIT("PER_UNIT"),
     /** The flat rate. */
-    FLAT_RATE("flat-rate");
+    FLAT_RATE("FLAT_RATE");
 
     @JsonValue
     private final String internalName;

--- a/src/test/resources/org/kohsuke/github/GHMarketplacePlanTest/wiremock/listAccounts/__files/body-marketplace_listing-stubbed-plans-7-accounts-QgHUA.json
+++ b/src/test/resources/org/kohsuke/github/GHMarketplacePlanTest/wiremock/listAccounts/__files/body-marketplace_listing-stubbed-plans-7-accounts-QgHUA.json
@@ -53,7 +53,7 @@
         "monthly_price_in_cents": 1099,
         "yearly_price_in_cents": 11870,
         "has_free_trial": false,
-        "price_model": "per-unit",
+        "price_model": "PER_UNIT",
         "state": "published",
         "unit_name": "seat",
         "bullets": [
@@ -80,7 +80,7 @@
         "monthly_price_in_cents": 1099,
         "yearly_price_in_cents": 11870,
         "has_free_trial": false,
-        "price_model": "per-unit",
+        "price_model": "PER_UNIT",
         "state": "published",
         "unit_name": "seat",
         "bullets": [

--- a/src/test/resources/org/kohsuke/github/GHMarketplacePlanTest/wiremock/listAccounts/__files/body-marketplace_listing-stubbed-plans-7-accounts-QgHUA.json
+++ b/src/test/resources/org/kohsuke/github/GHMarketplacePlanTest/wiremock/listAccounts/__files/body-marketplace_listing-stubbed-plans-7-accounts-QgHUA.json
@@ -24,7 +24,7 @@
         "monthly_price_in_cents": 1099,
         "yearly_price_in_cents": 11870,
         "has_free_trial": false,
-        "price_model": "flat-rate",
+        "price_model": "FLAT_RATE",
         "state": "published",
         "unit_name": null,
         "bullets": [

--- a/src/test/resources/org/kohsuke/github/GHMarketplacePlanTest/wiremock/listAccounts/__files/body-marketplace_listing-stubbed-plans-C43G2.json
+++ b/src/test/resources/org/kohsuke/github/GHMarketplacePlanTest/wiremock/listAccounts/__files/body-marketplace_listing-stubbed-plans-C43G2.json
@@ -8,7 +8,7 @@
     "description": "A free CI solution",
     "monthly_price_in_cents": 0,
     "yearly_price_in_cents": 0,
-    "price_model": "free",
+    "price_model": "FREE",
     "has_free_trial": false,
     "state": "published",
     "unit_name": null,
@@ -45,7 +45,7 @@
     "monthly_price_in_cents": 1099,
     "yearly_price_in_cents": 11870,
     "has_free_trial": false,
-    "price_model": "flat-rate",
+    "price_model": "FLAT_RATE",
     "state": "published",
     "unit_name": null,
     "bullets": [

--- a/src/test/resources/org/kohsuke/github/GHMarketplacePlanTest/wiremock/listAccounts/__files/body-marketplace_listing-stubbed-plans-C43G2.json
+++ b/src/test/resources/org/kohsuke/github/GHMarketplacePlanTest/wiremock/listAccounts/__files/body-marketplace_listing-stubbed-plans-C43G2.json
@@ -27,7 +27,7 @@
     "monthly_price_in_cents": 1099,
     "yearly_price_in_cents": 11870,
     "has_free_trial": false,
-    "price_model": "per-unit",
+    "price_model": "PER_UNIT",
     "state": "published",
     "unit_name": "seat",
     "bullets": [

--- a/src/test/resources/org/kohsuke/github/GHMarketplacePlanTest/wiremock/listAccountsWithDirection/__files/body-marketplace_listing-stubbed-plans-7-accounts-aoRnP.json
+++ b/src/test/resources/org/kohsuke/github/GHMarketplacePlanTest/wiremock/listAccountsWithDirection/__files/body-marketplace_listing-stubbed-plans-7-accounts-aoRnP.json
@@ -53,7 +53,7 @@
         "monthly_price_in_cents": 1099,
         "yearly_price_in_cents": 11870,
         "has_free_trial": false,
-        "price_model": "per-unit",
+        "price_model": "PER_UNIT",
         "state": "published",
         "unit_name": "seat",
         "bullets": [
@@ -80,7 +80,7 @@
         "monthly_price_in_cents": 1099,
         "yearly_price_in_cents": 11870,
         "has_free_trial": false,
-        "price_model": "per-unit",
+        "price_model": "PER_UNIT",
         "state": "published",
         "unit_name": "seat",
         "bullets": [

--- a/src/test/resources/org/kohsuke/github/GHMarketplacePlanTest/wiremock/listAccountsWithDirection/__files/body-marketplace_listing-stubbed-plans-7-accounts-aoRnP.json
+++ b/src/test/resources/org/kohsuke/github/GHMarketplacePlanTest/wiremock/listAccountsWithDirection/__files/body-marketplace_listing-stubbed-plans-7-accounts-aoRnP.json
@@ -24,7 +24,7 @@
         "monthly_price_in_cents": 1099,
         "yearly_price_in_cents": 11870,
         "has_free_trial": false,
-        "price_model": "flat-rate",
+        "price_model": "FLAT_RATE",
         "state": "published",
         "unit_name": null,
         "bullets": [

--- a/src/test/resources/org/kohsuke/github/GHMarketplacePlanTest/wiremock/listAccountsWithDirection/__files/body-marketplace_listing-stubbed-plans-8-accounts-NZw9v.json
+++ b/src/test/resources/org/kohsuke/github/GHMarketplacePlanTest/wiremock/listAccountsWithDirection/__files/body-marketplace_listing-stubbed-plans-8-accounts-NZw9v.json
@@ -53,7 +53,7 @@
         "monthly_price_in_cents": 1099,
         "yearly_price_in_cents": 11870,
         "has_free_trial": false,
-        "price_model": "per-unit",
+        "price_model": "PER_UNIT",
         "state": "published",
         "unit_name": "seat",
         "bullets": [
@@ -80,7 +80,7 @@
         "monthly_price_in_cents": 1099,
         "yearly_price_in_cents": 11870,
         "has_free_trial": false,
-        "price_model": "per-unit",
+        "price_model": "PER_UNIT",
         "state": "published",
         "unit_name": "seat",
         "bullets": [

--- a/src/test/resources/org/kohsuke/github/GHMarketplacePlanTest/wiremock/listAccountsWithDirection/__files/body-marketplace_listing-stubbed-plans-8-accounts-NZw9v.json
+++ b/src/test/resources/org/kohsuke/github/GHMarketplacePlanTest/wiremock/listAccountsWithDirection/__files/body-marketplace_listing-stubbed-plans-8-accounts-NZw9v.json
@@ -24,7 +24,7 @@
         "monthly_price_in_cents": 1099,
         "yearly_price_in_cents": 11870,
         "has_free_trial": false,
-        "price_model": "flat-rate",
+        "price_model": "FLAT_RATE",
         "state": "published",
         "unit_name": null,
         "bullets": [

--- a/src/test/resources/org/kohsuke/github/GHMarketplacePlanTest/wiremock/listAccountsWithDirection/__files/body-marketplace_listing-stubbed-plans-9-accounts-b1MbT.json
+++ b/src/test/resources/org/kohsuke/github/GHMarketplacePlanTest/wiremock/listAccountsWithDirection/__files/body-marketplace_listing-stubbed-plans-9-accounts-b1MbT.json
@@ -53,7 +53,7 @@
         "monthly_price_in_cents": 1099,
         "yearly_price_in_cents": 11870,
         "has_free_trial": false,
-        "price_model": "per-unit",
+        "price_model": "PER_UNIT",
         "state": "published",
         "unit_name": "seat",
         "bullets": [
@@ -80,7 +80,7 @@
         "monthly_price_in_cents": 1099,
         "yearly_price_in_cents": 11870,
         "has_free_trial": false,
-        "price_model": "per-unit",
+        "price_model": "PER_UNIT",
         "state": "published",
         "unit_name": "seat",
         "bullets": [

--- a/src/test/resources/org/kohsuke/github/GHMarketplacePlanTest/wiremock/listAccountsWithDirection/__files/body-marketplace_listing-stubbed-plans-9-accounts-b1MbT.json
+++ b/src/test/resources/org/kohsuke/github/GHMarketplacePlanTest/wiremock/listAccountsWithDirection/__files/body-marketplace_listing-stubbed-plans-9-accounts-b1MbT.json
@@ -24,7 +24,7 @@
         "monthly_price_in_cents": 1099,
         "yearly_price_in_cents": 11870,
         "has_free_trial": false,
-        "price_model": "flat-rate",
+        "price_model": "FLAT_RATE",
         "state": "published",
         "unit_name": null,
         "bullets": [

--- a/src/test/resources/org/kohsuke/github/GHMarketplacePlanTest/wiremock/listAccountsWithDirection/__files/body-marketplace_listing-stubbed-plans-uewkE.json
+++ b/src/test/resources/org/kohsuke/github/GHMarketplacePlanTest/wiremock/listAccountsWithDirection/__files/body-marketplace_listing-stubbed-plans-uewkE.json
@@ -8,7 +8,7 @@
     "description": "A free CI solution",
     "monthly_price_in_cents": 0,
     "yearly_price_in_cents": 0,
-    "price_model": "free",
+    "price_model": "FREE",
     "has_free_trial": false,
     "state": "published",
     "unit_name": null,
@@ -45,7 +45,7 @@
     "monthly_price_in_cents": 1099,
     "yearly_price_in_cents": 11870,
     "has_free_trial": false,
-    "price_model": "flat-rate",
+    "price_model": "FLAT_RATE",
     "state": "published",
     "unit_name": null,
     "bullets": [

--- a/src/test/resources/org/kohsuke/github/GHMarketplacePlanTest/wiremock/listAccountsWithDirection/__files/body-marketplace_listing-stubbed-plans-uewkE.json
+++ b/src/test/resources/org/kohsuke/github/GHMarketplacePlanTest/wiremock/listAccountsWithDirection/__files/body-marketplace_listing-stubbed-plans-uewkE.json
@@ -27,7 +27,7 @@
     "monthly_price_in_cents": 1099,
     "yearly_price_in_cents": 11870,
     "has_free_trial": false,
-    "price_model": "per-unit",
+    "price_model": "PER_UNIT",
     "state": "published",
     "unit_name": "seat",
     "bullets": [

--- a/src/test/resources/org/kohsuke/github/GHMarketplacePlanTest/wiremock/listAccountsWithSortAndDirection/__files/body-marketplace_listing-stubbed-plans-7-accounts-cz27N.json
+++ b/src/test/resources/org/kohsuke/github/GHMarketplacePlanTest/wiremock/listAccountsWithSortAndDirection/__files/body-marketplace_listing-stubbed-plans-7-accounts-cz27N.json
@@ -53,7 +53,7 @@
         "monthly_price_in_cents": 1099,
         "yearly_price_in_cents": 11870,
         "has_free_trial": false,
-        "price_model": "per-unit",
+        "price_model": "PER_UNIT",
         "state": "published",
         "unit_name": "seat",
         "bullets": [
@@ -80,7 +80,7 @@
         "monthly_price_in_cents": 1099,
         "yearly_price_in_cents": 11870,
         "has_free_trial": false,
-        "price_model": "per-unit",
+        "price_model": "PER_UNIT",
         "state": "published",
         "unit_name": "seat",
         "bullets": [

--- a/src/test/resources/org/kohsuke/github/GHMarketplacePlanTest/wiremock/listAccountsWithSortAndDirection/__files/body-marketplace_listing-stubbed-plans-7-accounts-cz27N.json
+++ b/src/test/resources/org/kohsuke/github/GHMarketplacePlanTest/wiremock/listAccountsWithSortAndDirection/__files/body-marketplace_listing-stubbed-plans-7-accounts-cz27N.json
@@ -24,7 +24,7 @@
         "monthly_price_in_cents": 1099,
         "yearly_price_in_cents": 11870,
         "has_free_trial": false,
-        "price_model": "flat-rate",
+        "price_model": "FLAT_RATE",
         "state": "published",
         "unit_name": null,
         "bullets": [

--- a/src/test/resources/org/kohsuke/github/GHMarketplacePlanTest/wiremock/listAccountsWithSortAndDirection/__files/body-marketplace_listing-stubbed-plans-8-accounts-8T1Pb.json
+++ b/src/test/resources/org/kohsuke/github/GHMarketplacePlanTest/wiremock/listAccountsWithSortAndDirection/__files/body-marketplace_listing-stubbed-plans-8-accounts-8T1Pb.json
@@ -53,7 +53,7 @@
         "monthly_price_in_cents": 1099,
         "yearly_price_in_cents": 11870,
         "has_free_trial": false,
-        "price_model": "per-unit",
+        "price_model": "PER_UNIT",
         "state": "published",
         "unit_name": "seat",
         "bullets": [
@@ -80,7 +80,7 @@
         "monthly_price_in_cents": 1099,
         "yearly_price_in_cents": 11870,
         "has_free_trial": false,
-        "price_model": "per-unit",
+        "price_model": "PER_UNIT",
         "state": "published",
         "unit_name": "seat",
         "bullets": [

--- a/src/test/resources/org/kohsuke/github/GHMarketplacePlanTest/wiremock/listAccountsWithSortAndDirection/__files/body-marketplace_listing-stubbed-plans-8-accounts-8T1Pb.json
+++ b/src/test/resources/org/kohsuke/github/GHMarketplacePlanTest/wiremock/listAccountsWithSortAndDirection/__files/body-marketplace_listing-stubbed-plans-8-accounts-8T1Pb.json
@@ -24,7 +24,7 @@
         "monthly_price_in_cents": 1099,
         "yearly_price_in_cents": 11870,
         "has_free_trial": false,
-        "price_model": "flat-rate",
+        "price_model": "FLAT_RATE",
         "state": "published",
         "unit_name": null,
         "bullets": [

--- a/src/test/resources/org/kohsuke/github/GHMarketplacePlanTest/wiremock/listAccountsWithSortAndDirection/__files/body-marketplace_listing-stubbed-plans-9-accounts-VT77w.json
+++ b/src/test/resources/org/kohsuke/github/GHMarketplacePlanTest/wiremock/listAccountsWithSortAndDirection/__files/body-marketplace_listing-stubbed-plans-9-accounts-VT77w.json
@@ -53,7 +53,7 @@
         "monthly_price_in_cents": 1099,
         "yearly_price_in_cents": 11870,
         "has_free_trial": false,
-        "price_model": "per-unit",
+        "price_model": "PER_UNIT",
         "state": "published",
         "unit_name": "seat",
         "bullets": [
@@ -80,7 +80,7 @@
         "monthly_price_in_cents": 1099,
         "yearly_price_in_cents": 11870,
         "has_free_trial": false,
-        "price_model": "per-unit",
+        "price_model": "PER_UNIT",
         "state": "published",
         "unit_name": "seat",
         "bullets": [

--- a/src/test/resources/org/kohsuke/github/GHMarketplacePlanTest/wiremock/listAccountsWithSortAndDirection/__files/body-marketplace_listing-stubbed-plans-9-accounts-VT77w.json
+++ b/src/test/resources/org/kohsuke/github/GHMarketplacePlanTest/wiremock/listAccountsWithSortAndDirection/__files/body-marketplace_listing-stubbed-plans-9-accounts-VT77w.json
@@ -24,7 +24,7 @@
         "monthly_price_in_cents": 1099,
         "yearly_price_in_cents": 11870,
         "has_free_trial": false,
-        "price_model": "flat-rate",
+        "price_model": "FLAT_RATE",
         "state": "published",
         "unit_name": null,
         "bullets": [

--- a/src/test/resources/org/kohsuke/github/GHMarketplacePlanTest/wiremock/listAccountsWithSortAndDirection/__files/body-marketplace_listing-stubbed-plans-xk1MF.json
+++ b/src/test/resources/org/kohsuke/github/GHMarketplacePlanTest/wiremock/listAccountsWithSortAndDirection/__files/body-marketplace_listing-stubbed-plans-xk1MF.json
@@ -8,7 +8,7 @@
     "description": "A free CI solution",
     "monthly_price_in_cents": 0,
     "yearly_price_in_cents": 0,
-    "price_model": "free",
+    "price_model": "FREE",
     "has_free_trial": false,
     "state": "published",
     "unit_name": null,
@@ -45,7 +45,7 @@
     "monthly_price_in_cents": 1099,
     "yearly_price_in_cents": 11870,
     "has_free_trial": false,
-    "price_model": "flat-rate",
+    "price_model": "FLAT_RATE",
     "state": "published",
     "unit_name": null,
     "bullets": [

--- a/src/test/resources/org/kohsuke/github/GHMarketplacePlanTest/wiremock/listAccountsWithSortAndDirection/__files/body-marketplace_listing-stubbed-plans-xk1MF.json
+++ b/src/test/resources/org/kohsuke/github/GHMarketplacePlanTest/wiremock/listAccountsWithSortAndDirection/__files/body-marketplace_listing-stubbed-plans-xk1MF.json
@@ -27,7 +27,7 @@
     "monthly_price_in_cents": 1099,
     "yearly_price_in_cents": 11870,
     "has_free_trial": false,
-    "price_model": "per-unit",
+    "price_model": "PER_UNIT",
     "state": "published",
     "unit_name": "seat",
     "bullets": [

--- a/src/test/resources/org/kohsuke/github/GHMarketplacePlanTest/wiremock/listMarketplacePlans/__files/body-marketplace_listing-stubbed-plans-ZDjdu.json
+++ b/src/test/resources/org/kohsuke/github/GHMarketplacePlanTest/wiremock/listMarketplacePlans/__files/body-marketplace_listing-stubbed-plans-ZDjdu.json
@@ -8,7 +8,7 @@
     "description": "A free CI solution",
     "monthly_price_in_cents": 0,
     "yearly_price_in_cents": 0,
-    "price_model": "free",
+    "price_model": "FREE",
     "has_free_trial": false,
     "state": "published",
     "unit_name": null,
@@ -27,7 +27,7 @@
     "monthly_price_in_cents": 1099,
     "yearly_price_in_cents": 11870,
     "has_free_trial": false,
-    "price_model": "per-unit",
+    "price_model": "PER_UNIT",
     "state": "published",
     "unit_name": "seat",
     "bullets": [
@@ -45,7 +45,7 @@
     "monthly_price_in_cents": 1099,
     "yearly_price_in_cents": 11870,
     "has_free_trial": false,
-    "price_model": "flat-rate",
+    "price_model": "FLAT_RATE",
     "state": "published",
     "unit_name": null,
     "bullets": [

--- a/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/getMyMarketplacePurchases/__files/body-user-marketplace_purchases-stubbed-eVWvD.json
+++ b/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/getMyMarketplacePurchases/__files/body-user-marketplace_purchases-stubbed-eVWvD.json
@@ -24,7 +24,7 @@
       "monthly_price_in_cents": 1099,
       "yearly_price_in_cents": 11870,
       "has_free_trial": false,
-      "price_model": "flat-rate",
+      "price_model": "FLAT_RATE",
       "state": "published",
       "unit_name": null,
       "bullets": [
@@ -56,7 +56,7 @@
       "description": "A free CI solution",
       "monthly_price_in_cents": 0,
       "yearly_price_in_cents": 0,
-      "price_model": "free",
+      "price_model": "FREE",
       "has_free_trial": false,
       "state": "published",
       "unit_name": null,


### PR DESCRIPTION
# Description

This fixes an issue reported in https://github.com/hub4j/github-api/issues/1613, where marketPlace plans type are not properly described (e.g. `per-unit` instead of `PER_UNIT`). This is confirmed by Github documentation https://docs.github.com/en/rest/apps/marketplace?apiVersion=2022-11-28#list-plans

Fixes #1613 

# Before submitting a PR:

- [x] Changes must not break binary backwards compatibility. If you are unclear on how to make the change you think is needed while maintaining backward compatibility, [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [x] Add JavaDocs and other comments as appropriate. Consider including links in comments to relevant documentation on https://docs.github.com/en/rest .  
- [x] Add tests that cover any added or changed code. This generally requires capturing snapshot test data. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [ ] Run `mvn -D enable-ci clean install site` locally. If this command doesn't succeed, your change will not pass CI.
- [x] Push your changes to a branch other than `main`. You will create your PR from that branch.

# When creating a PR: 

- [x] Fill in the "Description" above with clear summary of the changes. This includes:
  - [x] If this PR fixes one or more issues, include "Fixes #<issue number>" lines for each issue. 
  - [x] Provide links to relevant documentation on https://docs.github.com/en/rest where possible.
- [x] All lines of new code should be covered by tests as reported by code coverage. Any lines that are not covered must have PR comments explaining why they cannot be covered. For example, "Reaching this particular exception is hard and is not a particular common scenario."
- [ ] Enable "Allow edits from maintainers".
