### PR TITLE
Allowed creation of PR review comments using line number. Fixes #1645

### DIFF
--- a/src/main/java/org/kohsuke/github/GHPullRequestReviewBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequestReviewBuilder.java
@@ -73,14 +73,13 @@ public class GHPullRequestReviewBuilder {
 
     /**
      * Comment gh pull request review builder.
-     *
+     *          
      * @param body
-     *            The relative path to the file that necessitates a review comment.
-     * @param path
-     *            The position in the diff where you want to add a review comment. Note this value is not the same as
-     *            the line number in the file. For help finding the position value, read the note below.
-     * @param position
      *            Text of the review comment.
+     * @param path
+     *            The relative path to the file that necessitates a review comment.
+     * @param position
+     *            The line of the blob in the pull request diff that the comment applies to. 
      * @return the gh pull request review builder
      */
     public GHPullRequestReviewBuilder comment(String body, String path, int position) {
@@ -106,12 +105,12 @@ public class GHPullRequestReviewBuilder {
     private static class DraftReviewComment {
         private String body;
         private String path;
-        private int position;
+        private int line;
 
-        DraftReviewComment(String body, String path, int position) {
+        DraftReviewComment(String body, String path, int line) {
             this.body = body;
             this.path = path;
-            this.position = position;
+            this.line = line;
         }
 
         /**
@@ -133,12 +132,12 @@ public class GHPullRequestReviewBuilder {
         }
 
         /**
-         * Gets position.
+         * Gets line.
          *
-         * @return the position
+         * @return the line
          */
-        public int getPosition() {
-            return position;
+        public int getLine() {
+            return line;
         }
     }
 }


### PR DESCRIPTION
# Description
Fixes #1645

Updated org.kohsuke.github.GHPullRequestReviewBuilder to allow creating pull request review comments by line, instead of the deprecated parameter position. 

# Before submitting a PR:

- [x] Changes must not break binary backwards compatibility. If you are unclear on how to make the change you think is needed while maintaining backward compatibility, [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [x] Add JavaDocs and other comments as appropriate. Consider including links in comments to relevant documentation on https://docs.github.com/en/rest .  
- [ ] Add tests that cover any added or changed code. This generally requires capturing snapshot test data. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [ ] Run `mvn -D enable-ci clean install site` locally. If this command doesn't succeed, your change will not pass CI.
- [x] Push your changes to a branch other than `main`. You will create your PR from that branch.

# When creating a PR: 

- [x] Fill in the "Description" above with clear summary of the changes. This includes:
  - [x] If this PR fixes one or more issues, include "Fixes #<issue number>" lines for each issue. 
  - [ ] Provide links to relevant documentation on https://docs.github.com/en/rest where possible.
- [x] All lines of new code should be covered by tests as reported by code coverage. Any lines that are not covered must have PR comments explaining why they cannot be covered. For example, "Reaching this particular exception is hard and is not a particular common scenario."
- [x] Enable "Allow edits from maintainers".
