### PR TITLE
Ignoring Unnecessarily generated japicmp direcory

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Maven Install (skipTests)
         env:
           MAVEN_OPTS: ${{ env.JAVA_11_PLUS_MAVEN_OPTS }}
-        run: mvn -B clean install -DskipTests --file pom.xml
+        run: mvn -B clean install -DskipTests -Djapicmp.skip --file pom.xml
   site:
     name: site (Java ${{ matrix.java }})
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Description

In our analysis, we observe that this target/japicmp/ directory is generated but not later used during the CI build. Hence, we propose to disable generating this directory to save runtime.

The generation of this directory can be disabled by simply adding -Djapicmp.skip to the mvn command.