### PR TITLE
Ignoring unnecessarily generated surefire-report

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -74,7 +74,7 @@ jobs:
         cache: 'maven'
     # JDK 8
     - name: Maven Install with Code Coverage
-      run: mvn -B clean install -D enable-ci -Djapicmp.skip --file pom.xml
+      run: mvn -B clean install -D enable-ci -Djapicmp.skip --file pom.xml -Dsurefire.useFile=false -DdisableXmlReport=true
     - name: Codecov Report 
       uses: codecov/codecov-action@v3.1.1
   test:


### PR DESCRIPTION
In our analysis, we observe that this target/surefire-report/ directory is generated but not later used during the CI build. Hence, we propose to disable generating this directory to save runtime.
The generation of this directory can be disabled by simply adding -Dsurefire.useFile=false -DdisableXmlReport=true to the mvn command.