### PR TITLE
#1671 Remove unreleased MAINTAIN and TRIAGE permissions added during GitHub outage

### DIFF
--- a/src/main/java/org/kohsuke/github/GHPermissionType.java
+++ b/src/main/java/org/kohsuke/github/GHPermissionType.java
@@ -10,12 +10,8 @@ public enum GHPermissionType {
 
     /** The admin. */
     ADMIN(30),
-    /** The maintain. */
-    MAINTAIN(25),
     /** The write. */
     WRITE(20),
-    /** The triage. */
-    TRIAGE(15),
     /** The read. */
     READ(10),
     /** The none. */

--- a/src/test/java/org/kohsuke/github/EnumTest.java
+++ b/src/test/java/org/kohsuke/github/EnumTest.java
@@ -55,7 +55,7 @@ public class EnumTest extends AbstractGitHubWireMockTest {
         assertThat(GHOrganization.Role.values().length, equalTo(2));
         assertThat(GHOrganization.Permission.values().length, equalTo(5));
 
-        assertThat(GHPermissionType.values().length, equalTo(7));
+        assertThat(GHPermissionType.values().length, equalTo(5));
 
         assertThat(GHProject.ProjectState.values().length, equalTo(2));
         assertThat(GHProject.ProjectStateFilter.values().length, equalTo(3));

--- a/src/test/java/org/kohsuke/github/GHRepositoryTest.java
+++ b/src/test/java/org/kohsuke/github/GHRepositoryTest.java
@@ -1596,7 +1596,10 @@ public class GHRepositoryTest extends AbstractGitHubWireMockTest {
     }
 
     /**
-     * Test demoing the issue with a user having the maintain permission on a repository.
+     * Test checking the permission fallback mechanism in case the Github API changes. The test was recorded at a time a
+     * new permission was added by mistake. If a re-recording it is needed, you'll like have to manually edit the
+     * generated mocks to get a non existing permission See
+     * https://github.com/hub4j/github-api/issues/1671#issuecomment-1577515662 for the details.
      *
      * @throws IOException
      *             the exception
@@ -1605,6 +1608,6 @@ public class GHRepositoryTest extends AbstractGitHubWireMockTest {
     public void cannotRetrievePermissionMaintainUser() throws IOException {
         GHRepository r = gitHub.getRepository("hub4j-test-org/maintain-permission-issue");
         GHPermissionType permission = r.getPermission("alecharp");
-        assertThat(permission.toString(), is("MAINTAIN"));
+        assertThat(permission.toString(), is("UNKNOWN"));
     }
 }


### PR DESCRIPTION
# Description

Permissions added to the enum in #1672 do not make sense anymore since the Github Rest API change was roll-backed with no intention of re-introducing this change (as per: https://github.com/hub4j/github-api/issues/1671#issuecomment-1577515662).

In order to clean things up, this is a partial revert of #1672 only keeping the fallback logic.

I intentionally deleted the enum members instead of deprecating them, I don't really see a use case where somebody would have used the new enum values since the library was released around the same time Github rollbacked their changes.

# Before submitting a PR:

- [ ] Changes must not break binary backwards compatibility. If you are unclear on how to make the change you think is needed while maintaining backward compatibility, [CONTRIBUTING.md](CONTRIBUTING.md) for details. -> *SEE MY COMMENT above!*
- [x] Add JavaDocs and other comments explaining the behavior. 
- [ ] When adding or updating methods that fetch entities, add `@link` JavaDoc entries to the relevant documentation on https://docs.github.com/en/rest . 
- [x] Add tests that cover any added or changed code. This generally requires capturing snapshot test data. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [x] Run `mvn -D enable-ci clean install site` locally. If this command doesn't succeed, your change will not pass CI.
- [x] Push your changes to a branch other than `main`. You will create your PR from that branch.

# When creating a PR: 

- [x] Fill in the "Description" above with clear summary of the changes. This includes:
  - [x] If this PR fixes one or more issues, include "Fixes #<issue number>" lines for each issue. 
  - [ ] Provide links to relevant documentation on https://docs.github.com/en/rest where possible. If not including links, explain why not.
- [x] All lines of new code should be covered by tests as reported by code coverage. Any lines that are not covered must have PR comments explaining why they cannot be covered. For example, "Reaching this particular exception is hard and is not a particular common scenario."
- [x] Enable "Allow edits from maintainers".
