### PR TITLE
fix(sec): upgrade com.squareup.okio:okio to 3.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <spotbugs-maven-plugin.failOnError>true</spotbugs-maven-plugin.failOnError>
     <hamcrest.version>2.2</hamcrest.version>
     <okhttp3.version>4.9.2</okhttp3.version>
-    <okio.version>2.10.0</okio.version>
+    <okio.version>3.4.0</okio.version>
     <!-- Using this as the minimum bar for code coverage.  Adding methods without covering them will fail this. -->
     <jacoco.coverage.target.bundle.method>0.70</jacoco.coverage.target.bundle.method>
     <jacoco.coverage.target.class.method>0.50</jacoco.coverage.target.class.method>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <spotbugs-maven-plugin.failOnError>true</spotbugs-maven-plugin.failOnError>
     <hamcrest.version>2.2</hamcrest.version>
     <okhttp3.version>4.9.2</okhttp3.version>
-    <okio.version>3.4.0</okio.version>
+    <okio.version>3.5.0</okio.version>
     <!-- Using this as the minimum bar for code coverage.  Adding methods without covering them will fail this. -->
     <jacoco.coverage.target.bundle.method>0.70</jacoco.coverage.target.bundle.method>
     <jacoco.coverage.target.class.method>0.50</jacoco.coverage.target.class.method>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.squareup.okio:okio 2.10.0
- [CVE-2023-3635](https://www.oscs1024.com/hd/CVE-2023-3635)


### What did I do？
Upgrade com.squareup.okio:okio from 2.10.0 to 3.4.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS