### PR TITLE
fix: remove duplicate `method()` calls in GHContent class

### DIFF
--- a/src/main/java/org/kohsuke/github/GHContent.java
+++ b/src/main/java/org/kohsuke/github/GHContent.java
@@ -321,12 +321,11 @@ public class GHContent extends GitHubInteractiveObject implements Refreshable {
         String encodedContent = Base64.getEncoder().encodeToString(newContentBytes);
 
         Requester requester = root().createRequest()
-                .method("POST")
+                .method("PUT")
                 .with("path", path)
                 .with("message", commitMessage)
                 .with("sha", sha)
-                .with("content", encodedContent)
-                .method("PUT");
+                .with("content", encodedContent);
 
         if (branch != null) {
             requester.with("branch", branch);
@@ -368,11 +367,10 @@ public class GHContent extends GitHubInteractiveObject implements Refreshable {
      */
     public GHContentUpdateResponse delete(String commitMessage, String branch) throws IOException {
         Requester requester = root().createRequest()
-                .method("POST")
+                .method("DELETE")
                 .with("path", path)
                 .with("message", commitMessage)
-                .with("sha", sha)
-                .method("DELETE");
+                .with("sha", sha);
 
         if (branch != null) {
             requester.with("branch", branch);


### PR DESCRIPTION
# Description

While reading the code, I saw those duplicate `method()`. I am not sure they are present on purpose, do they?

# Before submitting a PR:

- [x] Changes must not break binary backwards compatibility. If you are unclear on how to make the change you think is needed while maintaining backward compatibility, [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [x] Add JavaDocs and other comments explaining the behavior. 
- [x] When adding or updating methods that fetch entities, add `@link` JavaDoc entries to the relevant documentation on https://docs.github.com/en/rest . 
- [x] Add tests that cover any added or changed code. This generally requires capturing snapshot test data. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [x] Run `mvn -D enable-ci clean install site` locally. If this command doesn't succeed, your change will not pass CI.
- [x] Push your changes to a branch other than `main`. You will create your PR from that branch.

# When creating a PR: 

- [x] Fill in the "Description" above with clear summary of the changes. This includes:
  - [x] If this PR fixes one or more issues, include "Fixes #<issue number>" lines for each issue. 
  - [x] Provide links to relevant documentation on https://docs.github.com/en/rest where possible. If not including links, explain why not.
- [x] All lines of new code should be covered by tests as reported by code coverage. Any lines that are not covered must have PR comments explaining why they cannot be covered. For example, "Reaching this particular exception is hard and is not a particular common scenario."
- [x] Enable "Allow edits from maintainers".
