### PR TITLE
Add allow_forking flag for a GHRepository

### DIFF
--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -103,6 +103,8 @@ public class GHRepository extends GHObject {
 
     private boolean allow_rebase_merge;
 
+    private boolean allow_forking;
+
     private boolean delete_branch_on_merge;
 
     @JsonProperty("private")
@@ -713,6 +715,15 @@ public class GHRepository extends GHObject {
      */
     public boolean isAllowRebaseMerge() {
         return allow_rebase_merge;
+    }
+
+    /**
+     * Is allow private forks
+     *
+     * @return the boolean
+     */
+    public boolean isAllowForking() {
+        return allow_forking;
     }
 
     /**
@@ -1459,6 +1470,18 @@ public class GHRepository extends GHObject {
      */
     public void allowRebaseMerge(boolean value) throws IOException {
         set().allowRebaseMerge(value);
+    }
+
+    /**
+     * Allow private fork.
+     *
+     * @param value
+     *            the value
+     * @throws IOException
+     *             the io exception
+     */
+    public void allowForking(boolean value) throws IOException {
+        set().allowForking(value);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHRepositoryBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHRepositoryBuilder.java
@@ -77,6 +77,19 @@ abstract class GHRepositoryBuilder<S> extends AbstractBuilder<GHRepository, S> {
     }
 
     /**
+     * Allow or disallow private forks
+     *
+     * @param enabled
+     *            true if enabled
+     * @return a builder to continue with building
+     * @throws IOException
+     *             In case of any networking error or error from the server.
+     */
+    public S allowForking(boolean enabled) throws IOException {
+        return with("allow_forking", enabled);
+    }
+
+    /**
      * After pull requests are merged, you can have head branches deleted automatically.
      *
      * @param enabled

--- a/src/test/java/org/kohsuke/github/AbstractGitHubWireMockTest.java
+++ b/src/test/java/org/kohsuke/github/AbstractGitHubWireMockTest.java
@@ -226,7 +226,7 @@ public abstract class AbstractGitHubWireMockTest {
      * Creates a temporary repository that will be deleted at the end of the test.
      *
      * @param name
-     *            string name of the the repository
+     *            string name of the repository
      *
      * @return a temporary repository
      * @throws IOException

--- a/src/test/java/org/kohsuke/github/GHRepositoryTest.java
+++ b/src/test/java/org/kohsuke/github/GHRepositoryTest.java
@@ -98,6 +98,7 @@ public class GHRepositoryTest extends AbstractGitHubWireMockTest {
         assertThat(r.isAllowMergeCommit(), is(true));
         assertThat(r.isAllowRebaseMerge(), is(true));
         assertThat(r.isAllowSquashMerge(), is(true));
+        assertThat(r.isAllowForking(), is(false));
 
         String httpTransport = "https://github.com/hub4j-test-org/temp-testGetters.git";
         assertThat(r.getHttpTransportUrl(), equalTo(httpTransport));
@@ -380,6 +381,7 @@ public class GHRepositoryTest extends AbstractGitHubWireMockTest {
         GHRepository updated = builder.allowRebaseMerge(false)
                 .allowSquashMerge(false)
                 .deleteBranchOnMerge(true)
+                .allowForking(true)
                 .description(description)
                 .downloads(false)
                 .downloads(false)
@@ -394,6 +396,7 @@ public class GHRepositoryTest extends AbstractGitHubWireMockTest {
         assertThat(updated.isAllowRebaseMerge(), is(false));
         assertThat(updated.isAllowSquashMerge(), is(false));
         assertThat(updated.isDeleteBranchOnMerge(), is(true));
+        assertThat(updated.isAllowForking(), is(true));
         assertThat(updated.isPrivate(), is(true));
         assertThat(updated.hasDownloads(), is(false));
         assertThat(updated.hasIssues(), is(false));

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testGetters/__files/repos_hub4j-test-org_temp-testgetters-2.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testGetters/__files/repos_hub4j-test-org_temp-testgetters-2.json
@@ -101,6 +101,7 @@
   "allow_merge_commit": true,
   "allow_rebase_merge": true,
   "delete_branch_on_merge": false,
+  "allow_forking": false,
   "organization": {
     "login": "hub4j-test-org",
     "id": 7544739,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testUpdateRepository/__files/repos_hub4j-test-org_temp-testupdaterepository-2.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testUpdateRepository/__files/repos_hub4j-test-org_temp-testupdaterepository-2.json
@@ -101,6 +101,7 @@
   "allow_merge_commit": true,
   "allow_rebase_merge": true,
   "delete_branch_on_merge": false,
+  "allow_forking": false,
   "organization": {
     "login": "hub4j-test-org",
     "id": 7544739,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testUpdateRepository/__files/repos_hub4j-test-org_temp-testupdaterepository-3.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testUpdateRepository/__files/repos_hub4j-test-org_temp-testupdaterepository-3.json
@@ -100,6 +100,7 @@
   "allow_merge_commit": true,
   "allow_rebase_merge": false,
   "delete_branch_on_merge": true,
+  "allow_forking": true,
   "organization": {
     "login": "hub4j-test-org",
     "id": 7544739,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testUpdateRepository/__files/repos_hub4j-test-org_temp-testupdaterepository-4.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testUpdateRepository/__files/repos_hub4j-test-org_temp-testupdaterepository-4.json
@@ -100,6 +100,7 @@
   "allow_merge_commit": false,
   "allow_rebase_merge": true,
   "delete_branch_on_merge": true,
+  "allow_forking": false,
   "organization": {
     "login": "hub4j-test-org",
     "id": 7544739,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testUpdateRepository/__files/repos_hub4j-test-org_temp-testupdaterepository-5.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testUpdateRepository/__files/repos_hub4j-test-org_temp-testupdaterepository-5.json
@@ -100,6 +100,7 @@
   "allow_merge_commit": false,
   "allow_rebase_merge": true,
   "delete_branch_on_merge": true,
+  "allow_forking": false,
   "organization": {
     "login": "hub4j-test-org",
     "id": 7544739,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testUpdateRepository/mappings/repos_hub4j-test-org_temp-testupdaterepository-3.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testUpdateRepository/mappings/repos_hub4j-test-org_temp-testupdaterepository-3.json
@@ -11,7 +11,7 @@
     },
     "bodyPatterns": [
       {
-        "equalToJson": "{\"name\":\"temp-testUpdateRepository\",\"has_projects\":false,\"allow_squash_merge\":false,\"private\":true,\"has_downloads\":false,\"has_wiki\":false,\"description\":\"A test repository for update testing via the github-api project\",\"delete_branch_on_merge\":true,\"allow_rebase_merge\":false,\"has_issues\":false,\"homepage\":\"https://github-api.kohsuke.org/apidocs/index.html\"}",
+        "equalToJson": "{\"name\":\"temp-testUpdateRepository\",\"has_projects\":false,\"allow_squash_merge\":false,\"allow_forking\":true,\"private\":true,\"has_downloads\":false,\"has_wiki\":false,\"description\":\"A test repository for update testing via the github-api project\",\"delete_branch_on_merge\":true,\"allow_rebase_merge\":false,\"has_issues\":false,\"homepage\":\"https://github-api.kohsuke.org/apidocs/index.html\"}",
         "ignoreArrayOrder": true,
         "ignoreExtraElements": false
       }


### PR DESCRIPTION
# Description
Fixes: #1588

Link to the docs: https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#update-a-repository

# Before submitting a PR:

- [x] Changes must not break binary backwards compatibility. If you are unclear on how to make the change you think is needed while maintaining backward compatibility, [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [x] Add JavaDocs and other comments explaining the behavior. 
- [x] When adding or updating methods that fetch entities, add `@link` JavaDoc entries to the relevant documentation on https://docs.github.com/en/rest . 
- [x] Add tests that cover any added or changed code. This generally requires capturing snapshot test data. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [x] Run `mvn -D enable-ci clean install site` locally. If this command doesn't succeed, your change will not pass CI.
- [x] Push your changes to a branch other than `main`. You will create your PR from that branch.

# When creating a PR: 

- [x] Fill in the "Description" above with clear summary of the changes. This includes:
  - [x] If this PR fixes one or more issues, include "Fixes #<issue number>" lines for each issue. 
  - [x] Provide links to relevant documentation on https://docs.github.com/en/rest where possible. If not including links, explain why not.
- [x] All lines of new code should be covered by tests as reported by code coverage. Any lines that are not covered must have PR comments explaining why they cannot be covered. For example, "Reaching this particular exception is hard and is not a particular common scenario."
- [x] Enable "Allow edits from maintainers".
