### PR TITLE
Github docs change the documentation url

### DIFF
--- a/src/test/java/org/kohsuke/github/WireMockStatusReporterTest.java
+++ b/src/test/java/org/kohsuke/github/WireMockStatusReporterTest.java
@@ -147,7 +147,7 @@ public class WireMockStatusReporterTest extends AbstractGitHubWireMockTest {
         assertThat(e, Matchers.<Exception>instanceOf(GHFileNotFoundException.class));
         assertThat(e.getMessage(),
                 containsString(
-                        "{\"message\":\"Not Found\",\"documentation_url\":\"https://docs.github.com/rest/reference/repos#get-a-repository\"}"));
+                        "{\"message\":\"Not Found\",\"documentation_url\":\"https://docs.github.com/rest/repos/repos#get-a-repository\"}"));
     }
 
     /**


### PR DESCRIPTION
# Description

<!-- Describe your change here -->
Github changed the documentation url  returned by their API from:
https://docs.github.com/rest/reference/repos#get-a-repository
to:
https://docs.github.com/rest/repos/repos#get-a-repository

This change updates assertion to the new URL

# Before submitting a PR:

- [x] Changes must not break binary backwards compatibility. If you are unclear on how to make the change you think is needed while maintaining backward compatibility, [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [x] Add JavaDocs and other comments explaining the behavior. 
- [x] When adding or updating methods that fetch entities, add `@link` JavaDoc entries to the relevant documentation on https://docs.github.com/en/rest . 
- [x] Add tests that cover any added or changed code. This generally requires capturing snapshot test data. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [x] Run `mvn -D enable-ci clean install site` locally. If this command doesn't succeed, your change will not pass CI.
- [x] Push your changes to a branch other than `main`. You will create your PR from that branch.

# When creating a PR: 

- [x] Fill in the "Description" above with clear summary of the changes. This includes:
- [x] If this PR fixes one or more issues, include "Fixes #<issue number>" lines for each issue. 
- [x] Provide links to relevant documentation on https://docs.github.com/en/rest where possible. If not including links, explain why not.
- [x] All lines of new code should be covered by tests as reported by code coverage. Any lines that are not covered must have PR comments explaining why they cannot be covered. For example, "Reaching this particular exception is hard and is not a particular common scenario."
- [x] Enable "Allow edits from maintainers".
