### PR TITLE
Add MANNEQUIN to GHCommentAuthorAssociation enum 

### DIFF
--- a/src/main/java/org/kohsuke/github/GHCommentAuthorAssociation.java
+++ b/src/main/java/org/kohsuke/github/GHCommentAuthorAssociation.java
@@ -26,7 +26,8 @@ public enum GHCommentAuthorAssociation {
     /**
      * Author is a placeholder for an unclaimed user.
      */
-    MANNEQUIN,    /**
+    MANNEQUIN,
+    /**
      * Author is a member of the organization that owns the repository.
      */
     MEMBER,

--- a/src/main/java/org/kohsuke/github/GHCommentAuthorAssociation.java
+++ b/src/main/java/org/kohsuke/github/GHCommentAuthorAssociation.java
@@ -34,5 +34,9 @@ public enum GHCommentAuthorAssociation {
     /**
      * Author is the owner of the repository.
      */
-    OWNER
+    OWNER,
+    /**
+     * Author is a placeholder for an unclaimed user.
+     */
+    MANNEQUIN
 }

--- a/src/main/java/org/kohsuke/github/GHCommentAuthorAssociation.java
+++ b/src/main/java/org/kohsuke/github/GHCommentAuthorAssociation.java
@@ -24,6 +24,9 @@ public enum GHCommentAuthorAssociation {
      */
     FIRST_TIME_CONTRIBUTOR,
     /**
+     * Author is a placeholder for an unclaimed user.
+     */
+    MANNEQUIN,    /**
      * Author is a member of the organization that owns the repository.
      */
     MEMBER,
@@ -34,9 +37,5 @@ public enum GHCommentAuthorAssociation {
     /**
      * Author is the owner of the repository.
      */
-    OWNER,
-    /**
-     * Author is a placeholder for an unclaimed user.
-     */
-    MANNEQUIN
+    OWNER
 }

--- a/src/test/java/org/kohsuke/github/EnumTest.java
+++ b/src/test/java/org/kohsuke/github/EnumTest.java
@@ -22,7 +22,7 @@ public class EnumTest extends AbstractGitHubWireMockTest {
         assertThat(GHCheckRun.Conclusion.values().length, equalTo(9));
         assertThat(GHCheckRun.Status.values().length, equalTo(4));
 
-        assertThat(GHCommentAuthorAssociation.values().length, equalTo(7));
+        assertThat(GHCommentAuthorAssociation.values().length, equalTo(8));
 
         assertThat(GHCommitState.values().length, equalTo(4));
 


### PR DESCRIPTION
# Description

This PR introduces the MANNEQUIN value to the GHCommentAuthorAssociation enum. This change is necessary to handle the unclaimed user scenario, particularly in migrated repositories where the user's association with the repository is not defined.

This fixes #1716.

<!-- Describe your change here -->

# Before submitting a PR:

- [ ] Changes must not break binary backwards compatibility. If you are unclear on how to make the change you think is needed while maintaining backward compatibility, [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [ ] Add JavaDocs and other comments explaining the behavior. 
- [ ] When adding or updating methods that fetch entities, add `@link` JavaDoc entries to the relevant documentation on https://docs.github.com/en/rest . 
- [ ] Add tests that cover any added or changed code. This generally requires capturing snapshot test data. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [ ] Run `mvn -D enable-ci clean install site` locally. If this command doesn't succeed, your change will not pass CI.
- [ ] Push your changes to a branch other than `main`. You will create your PR from that branch.

# When creating a PR: 

- [ ] Fill in the "Description" above with clear summary of the changes. This includes:
  - [ ] If this PR fixes one or more issues, include "Fixes #<issue number>" lines for each issue. 
  - [ ] Provide links to relevant documentation on https://docs.github.com/en/rest where possible. If not including links, explain why not.
- [ ] All lines of new code should be covered by tests as reported by code coverage. Any lines that are not covered must have PR comments explaining why they cannot be covered. For example, "Reaching this particular exception is hard and is not a particular common scenario."
- [ ] Enable "Allow edits from maintainers".
