### PR TITLE
Only try to strip upload url 'helpful garbage' if it is present

### DIFF
--- a/src/main/java/org/kohsuke/github/GHRelease.java
+++ b/src/main/java/org/kohsuke/github/GHRelease.java
@@ -275,7 +275,9 @@ public class GHRelease extends GHObject {
         String url = getUploadUrl();
         // strip the helpful garbage from the url
         int endIndex = url.indexOf('{');
-        if (endIndex != -1) url = url.substring(0, endIndex);
+        if (endIndex != -1) {
+            url = url.substring(0, endIndex);
+        }
         url += "?name=" + URLEncoder.encode(filename, "UTF-8");
         return builder.contentType(contentType).with(stream).withUrlPath(url).fetch(GHAsset.class).wrap(this);
     }

--- a/src/main/java/org/kohsuke/github/GHRelease.java
+++ b/src/main/java/org/kohsuke/github/GHRelease.java
@@ -274,7 +274,8 @@ public class GHRelease extends GHObject {
         Requester builder = owner.root().createRequest().method("POST");
         String url = getUploadUrl();
         // strip the helpful garbage from the url
-        url = url.substring(0, url.indexOf('{'));
+        int endIndex = url.indexOf('{');
+        if (endIndex != -1) url = url.substring(0, endIndex);
         url += "?name=" + URLEncoder.encode(filename, "UTF-8");
         return builder.contentType(contentType).with(stream).withUrlPath(url).fetch(GHAsset.class).wrap(this);
     }


### PR DESCRIPTION
This library is mostly compatible with the Gitea API, which although somewhat incidental, is nonetheless wonderful. However, it fails to upload release assets due to this one small and easily-fixed issue. Adding this check does not in any way obstruct the normal use of the GitHub API.

# Description

The GHRelease.uploadAsset method substrings the upload URL to grab the URL before the 'helpful garbage' provided by GitHub, which begins with a '{' character. However, if the upload URL does not have a '{' character in it for some reason (such as the API actually being provided by Gitea, not GitHub), this method throws an exception. This change simply adds a check to avoid this exception.

# Before submitting a PR:

- [x] Changes must not break binary backwards compatibility. If you are unclear on how to make the change you think is needed while maintaining backward compatibility, [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [x] Add JavaDocs and other comments explaining the behavior. 
- [x] When adding or updating methods that fetch entities, add `@link` JavaDoc entries to the relevant documentation on https://docs.github.com/en/rest . 
- [x] Add tests that cover any added or changed code. This generally requires capturing snapshot test data. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [x] Run `mvn -D enable-ci clean install site` locally. If this command doesn't succeed, your change will not pass CI.
- [x] Push your changes to a branch other than `main`. You will create your PR from that branch.

# When creating a PR: 

- [x] Fill in the "Description" above with clear summary of the changes. This includes:
  - [x] If this PR fixes one or more issues, include "Fixes #<issue number>" lines for each issue. 
  - [x] Provide links to relevant documentation on https://docs.github.com/en/rest where possible. If not including links, explain why not.
- [x] All lines of new code should be covered by tests as reported by code coverage. Any lines that are not covered must have PR comments explaining why they cannot be covered. For example, "Reaching this particular exception is hard and is not a particular common scenario."
- [x] Enable "Allow edits from maintainers".
