### PR TITLE
Added all possible status values from GH api spec.

### DIFF
--- a/src/main/java/org/kohsuke/github/GHWorkflowRun.java
+++ b/src/main/java/org/kohsuke/github/GHWorkflowRun.java
@@ -502,6 +502,28 @@ public class GHWorkflowRun extends GHObject {
         IN_PROGRESS,
         /** The completed. */
         COMPLETED,
+        /** The action required. */
+        ACTION_REQUIRED,
+        /** The cancelled. */
+        CANCELLED,
+        /** The failure. */
+        FAILURE,
+        /** The neutral. */
+        NEUTRAL,
+        /** The skipped. */
+        SKIPPED,
+        /** The stale. */
+        STALE,
+        /** The success. */
+        SUCCESS,
+        /** The timed out. */
+        TIMED_OUT,
+        /** The requested. */
+        REQUESTED,
+        /** The waiting. */
+        WAITING,
+        /** The pending. */
+        PENDING,
         /** The unknown. */
         UNKNOWN;
 

--- a/src/test/java/org/kohsuke/github/EnumTest.java
+++ b/src/test/java/org/kohsuke/github/EnumTest.java
@@ -1,7 +1,6 @@
 package org.kohsuke.github;
 
 import org.junit.Test;
-import org.kohsuke.github.GHPullRequest.MergeMethod;
 import org.kohsuke.github.internal.Previews;
 
 import static org.hamcrest.CoreMatchers.*;
@@ -29,9 +28,13 @@ public class EnumTest extends AbstractGitHubWireMockTest {
 
         assertThat(GHCommentAuthorAssociation.values().length, equalTo(8));
 
+        assertThat(GHCommitSearchBuilder.Sort.values().length, equalTo(2));
+
         assertThat(GHCommitState.values().length, equalTo(4));
 
         assertThat(GHCompare.Status.values().length, equalTo(4));
+
+        assertThat(GHContentSearchBuilder.Sort.values().length, equalTo(2));
 
         assertThat(GHDeploymentState.values().length, equalTo(7));
 
@@ -41,9 +44,16 @@ public class EnumTest extends AbstractGitHubWireMockTest {
         assertThat(GHEvent.ALL.symbol(), equalTo("*"));
         assertThat(GHEvent.PULL_REQUEST.symbol(), equalTo(GHEvent.PULL_REQUEST.toString().toLowerCase()));
 
+        assertThat(GHFork.values().length, equalTo(3));
+        assertThat(GHFork.PARENT_ONLY.toString(), equalTo(""));
+
+        assertThat(GHIssueQueryBuilder.Sort.values().length, equalTo(3));
+
         assertThat(GHIssueSearchBuilder.Sort.values().length, equalTo(3));
 
         assertThat(GHIssueState.values().length, equalTo(3));
+
+        assertThat(GHIssueStateReason.values().length, equalTo(3));
 
         assertThat(GHMarketplaceAccountType.values().length, equalTo(2));
 
@@ -65,9 +75,15 @@ public class EnumTest extends AbstractGitHubWireMockTest {
         assertThat(GHProject.ProjectState.values().length, equalTo(2));
         assertThat(GHProject.ProjectStateFilter.values().length, equalTo(3));
 
-        assertThat(MergeMethod.values().length, equalTo(3));
+        assertThat(GHProjectsV2Item.ContentType.values().length, equalTo(4));
+
+        assertThat(GHProjectsV2ItemChanges.FieldType.values().length, equalTo(6));
+
+        assertThat(GHPullRequest.MergeMethod.values().length, equalTo(3));
 
         assertThat(GHPullRequestQueryBuilder.Sort.values().length, equalTo(4));
+
+        assertThat(GHPullRequestReviewComment.Side.values().length, equalTo(3));
 
         assertThat(GHPullRequestReviewEvent.values().length, equalTo(4));
         assertThat(GHPullRequestReviewEvent.PENDING.toState(), equalTo(GHPullRequestReviewState.PENDING));
@@ -78,20 +94,36 @@ public class EnumTest extends AbstractGitHubWireMockTest {
         assertThat(GHPullRequestReviewState.APPROVED.action(), equalTo(GHPullRequestReviewEvent.APPROVE.action()));
         assertThat(GHPullRequestReviewState.DISMISSED.toEvent(), nullValue());
 
+        assertThat(GHPullRequestSearchBuilder.Sort.values().length, equalTo(4));
+
+        assertThat(GHReleaseBuilder.MakeLatest.values().length, equalTo(3));
+
         assertThat(GHRepository.CollaboratorAffiliation.values().length, equalTo(3));
         assertThat(GHRepository.ForkSort.values().length, equalTo(3));
         assertThat(GHRepository.Visibility.values().length, equalTo(4));
 
+        assertThat(GHRepositoryDiscussion.State.values().length, equalTo(3));
+
         assertThat(GHRepositorySearchBuilder.Sort.values().length, equalTo(3));
+        assertThat(GHRepositorySearchBuilder.Fork.values().length, equalTo(3));
+        assertThat(GHRepositorySearchBuilder.Fork.PARENT_ONLY.toString(), equalTo(""));
 
         assertThat(GHRepositorySelection.values().length, equalTo(2));
+
+        assertThat(GHTargetType.values().length, equalTo(2));
 
         assertThat(GHTeam.Role.values().length, equalTo(2));
         assertThat(GHTeam.Privacy.values().length, equalTo(3));
 
         assertThat(GHUserSearchBuilder.Sort.values().length, equalTo(3));
 
-        assertThat(GHIssueQueryBuilder.Sort.values().length, equalTo(3));
-    }
+        assertThat(GHVerification.Reason.values().length, equalTo(18));
 
+        assertThat(GHWorkflowRun.Status.values().length, equalTo(15));
+        assertThat(GHWorkflowRun.Conclusion.values().length, equalTo(10));
+
+        assertThat(MarkdownMode.values().length, equalTo(2));
+
+        assertThat(ReactionContent.values().length, equalTo(8));
+    }
 }


### PR DESCRIPTION
Added all possible github workflow run status values specified in https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28

# Description

The Github REST API allows more values than available in the Status enum for GitWorkflowRuns.

# Before submitting a PR:

- [x ] Changes must not break binary backwards compatibility. If you are unclear on how to make the change you think is needed while maintaining backward compatibility, [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [ x] Add JavaDocs and other comments explaining the behavior. 
- [ x] When adding or updating methods that fetch entities, add `@link` JavaDoc entries to the relevant documentation on https://docs.github.com/en/rest . 
- [ ] Add tests that cover any added or changed code. This generally requires capturing snapshot test data. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [x ] Run `mvn -D enable-ci clean install site` locally. If this command doesn't succeed, your change will not pass CI.
- [x] Push your changes to a branch other than `main`. You will create your PR from that branch.

# When creating a PR: 

- [ x] Fill in the "Description" above with clear summary of the changes. This includes:
  - [ ] If this PR fixes one or more issues, include "Fixes #<issue number>" lines for each issue. 
  - [x] Provide links to relevant documentation on https://docs.github.com/en/rest where possible. If not including links, explain why not.
- [ ] All lines of new code should be covered by tests as reported by code coverage. Any lines that are not covered must have PR comments explaining why they cannot be covered. For example, "Reaching this particular exception is hard and is not a particular common scenario."
- [x ] Enable "Allow edits from maintainers".
