### PR TITLE
Populate GHUser before access a suspendedAt field value

### DIFF
--- a/src/main/java/org/kohsuke/github/GHUser.java
+++ b/src/main/java/org/kohsuke/github/GHUser.java
@@ -40,7 +40,7 @@ public class GHUser extends GHPerson {
     protected String ldap_dn;
 
     /** The suspended_at */
-    private String suspendedAt;
+    private String suspended_at;
 
     /**
      * Gets keys.
@@ -275,7 +275,8 @@ public class GHUser extends GHPerson {
      *             on error
      */
     public Date getSuspendedAt() throws IOException {
-        return GitHubClient.parseDate(suspendedAt);
+        super.populate();
+        return GitHubClient.parseDate(suspended_at);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHUser.java
+++ b/src/main/java/org/kohsuke/github/GHUser.java
@@ -40,7 +40,7 @@ public class GHUser extends GHPerson {
     protected String ldap_dn;
 
     /** The suspended_at */
-    private String suspended_at;
+    private String suspendedAt;
 
     /**
      * Gets keys.
@@ -276,7 +276,7 @@ public class GHUser extends GHPerson {
      */
     public Date getSuspendedAt() throws IOException {
         super.populate();
-        return GitHubClient.parseDate(suspended_at);
+        return GitHubClient.parseDate(suspendedAt);
     }
 
     /**


### PR DESCRIPTION
# Description
`GHUser#getSuspendedAt()` for a suspended user returns null if the object is not populated.
```kotlin
// for filter out suspended user

// not working: user object is not populated -> field value is always null
val users = github.listUsers()
     .filter { it.suspendedAt == null }
     .toList()

// working but tricky: call getCreatedAt() first -> populated -> getSuspendedAt() is not null
val users2 = github.listUsers()
    .filter { it.createdAt != null && it.suspendedAt == null }
    .toList()
```

This PR fixes
- Populate before access field value.
- ~Confirm field naming convention. (camelCase -> snake_case)~

FYI. This bug was introduced by PR #1906. (Released v1.324)


# Before submitting a PR:

- [x] Changes must not break binary backwards compatibility. If you are unclear on how to make the change you think is needed while maintaining backward compatibility, [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [x] Add JavaDocs and other comments explaining the behavior. 
- [x] When adding or updating methods that fetch entities, add `@link` JavaDoc entries to the relevant documentation on https://docs.github.com/en/rest . 
- [x] Add tests that cover any added or changed code. This generally requires capturing snapshot test data. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [x] Run `mvn -D enable-ci clean install site` locally. If this command doesn't succeed, your change will not pass CI.
- [x] Push your changes to a branch other than `main`. You will create your PR from that branch.

# When creating a PR: 

- [x] Fill in the "Description" above with clear summary of the changes. This includes:
  - [x] If this PR fixes one or more issues, include "Fixes #<issue number>" lines for each issue. 
  - [x] Provide links to relevant documentation on https://docs.github.com/en/rest where possible. If not including links, explain why not.
- [x] All lines of new code should be covered by tests as reported by code coverage. Any lines that are not covered must have PR comments explaining why they cannot be covered. For example, "Reaching this particular exception is hard and is not a particular common scenario."
- [x] Enable "Allow edits from maintainers".
