### PR TITLE
Extend license by spdx id field

### DIFF
--- a/src/main/java/org/kohsuke/github/GHLicense.java
+++ b/src/main/java/org/kohsuke/github/GHLicense.java
@@ -49,7 +49,7 @@ public class GHLicense extends GHObject {
 
     /** The name. */
     // these fields are always present, even in the short form
-    protected String key, name;
+    protected String key, name, spdxId;
 
     /** The featured. */
     // the rest is only after populated
@@ -83,6 +83,15 @@ public class GHLicense extends GHObject {
      */
     public String getName() {
         return name;
+    }
+
+    /**
+     * Gets SPDX ID.
+     *
+     * @return the spdx id
+     */
+    public String getSpdxId() {
+        return spdxId;
     }
 
     /**

--- a/src/test/java/org/kohsuke/github/GHLicenseTest.java
+++ b/src/test/java/org/kohsuke/github/GHLicenseTest.java
@@ -83,6 +83,7 @@ public class GHLicenseTest extends AbstractGitHubWireMockTest {
         GHLicense license = gitHub.getLicense(key);
         assertThat(license, notNullValue());
         assertThat("The name is correct", license.getName(), equalTo("MIT License"));
+        assertThat("The SPDX ID is correct", license.getSpdxId(), is(equalTo("MIT")));
         assertThat("The HTML URL is correct",
                 license.getHtmlUrl(),
                 equalTo(new URL("http://choosealicense.com/licenses/mit/")));
@@ -111,6 +112,7 @@ public class GHLicenseTest extends AbstractGitHubWireMockTest {
         GHLicense license = repo.getLicense();
         assertThat("The license is populated", license, notNullValue());
         assertThat("The key is correct", license.getKey(), equalTo("mit"));
+        assertThat("The SPDX ID is correct", license.getSpdxId(), is(equalTo("MIT")));
         assertThat("The name is correct", license.getName(), equalTo("MIT License"));
         assertThat("The URL is correct",
                 license.getUrl(),
@@ -129,6 +131,7 @@ public class GHLicenseTest extends AbstractGitHubWireMockTest {
         GHLicense license = repo.getLicense();
         assertThat("The license is populated", license, notNullValue());
         assertThat("The key is correct", license.getKey(), equalTo("mit"));
+        assertThat("The SPDX ID is correct", license.getSpdxId(), is(equalTo("MIT")));
         assertThat("The name is correct", license.getName(), equalTo("MIT License"));
         assertThat("The URL is correct",
                 license.getUrl(),
@@ -148,6 +151,7 @@ public class GHLicenseTest extends AbstractGitHubWireMockTest {
         GHLicense license = repo.getLicense();
         assertThat("The license is populated", license, notNullValue());
         assertThat("The key is correct", license.getKey(), equalTo("apache-2.0"));
+        assertThat("The SPDX ID is correct", license.getSpdxId(), is(equalTo("Apache-2.0")));
         assertThat("The name is correct", license.getName(), equalTo("Apache License 2.0"));
         assertThat("The URL is correct",
                 license.getUrl(),
@@ -181,6 +185,7 @@ public class GHLicenseTest extends AbstractGitHubWireMockTest {
         GHLicense license = repo.getLicense();
         assertThat("The license is populated", license, notNullValue());
         assertThat("The key is correct", license.getKey(), equalTo("mit"));
+        assertThat("The SPDX ID is correct", license.getSpdxId(), is(equalTo("MIT")));
         assertThat("The name is correct", license.getName(), equalTo("MIT License"));
         assertThat("The URL is correct",
                 license.getUrl(),


### PR DESCRIPTION
# Description

Github offers `spdx_id` field on all license related rest calls. This PR adds this to the `GHLicense` class.

# Before submitting a PR:

- [x] Changes must not break binary backwards compatibility. If you are unclear on how to make the change you think is needed while maintaining backward compatibility, [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [x] Add JavaDocs and other comments explaining the behavior. 
- [x] When adding or updating methods that fetch entities, add `@link` JavaDoc entries to the relevant documentation on https://docs.github.com/en/rest . 
- [x] Add tests that cover any added or changed code. This generally requires capturing snapshot test data. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [x] Run `mvn -D enable-ci clean install site` locally. If this command doesn't succeed, your change will not pass CI.
- [x] Push your changes to a branch other than `main`. You will create your PR from that branch.

# When creating a PR: 

- [x] Fill in the "Description" above with clear summary of the changes. This includes:
  - [x] If this PR fixes one or more issues, include "Fixes #<issue number>" lines for each issue. 
  - [x] Provide links to relevant documentation on https://docs.github.com/en/rest where possible. If not including links, explain why not.
- [x] All lines of new code should be covered by tests as reported by code coverage. Any lines that are not covered must have PR comments explaining why they cannot be covered. For example, "Reaching this particular exception is hard and is not a particular common scenario."
- [x] Enable "Allow edits from maintainers".
