### PR TITLE
fix GHNotificationStream "Unable to parse If-Modified-Since request header"

### DIFF
--- a/src/main/java/org/kohsuke/github/GHNotificationStream.java
+++ b/src/main/java/org/kohsuke/github/GHNotificationStream.java
@@ -187,7 +187,9 @@ public class GHNotificationStream extends GitHubInteractiveObject implements Ite
                             Thread.sleep(waitTime);
                         }
 
-                        req.setHeader("If-Modified-Since", lastModified);
+                        if (lastModified != null) {
+                            req.setHeader("If-Modified-Since", lastModified);
+                        }
 
                         Requester requester = req.withUrlPath(apiUrl);
                         GitHubResponse<GHThread[]> response = ((GitHubPageContentsIterable<GHThread>) requester

--- a/src/test/java/org/kohsuke/github/AppTest.java
+++ b/src/test/java/org/kohsuke/github/AppTest.java
@@ -1709,6 +1709,7 @@ public class AppTest extends AbstractGitHubWireMockTest {
         }
         assertThat(found, is(true));
         gitHub.listNotifications().markAsRead();
+        gitHub.listNotifications().iterator().next();
     }
 
     /**

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/__files/27-notifications.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/__files/27-notifications.json
@@ -1,0 +1,5 @@
+{
+  "message": "Unable to parse If-Modified-Since request header. Please make sure value is in an acceptable format.",
+  "documentation_url": "https://docs.github.com/rest/activity/notifications#list-notifications-for-the-authenticated-user",
+  "status": "422"
+}

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/26-notifications.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/26-notifications.json
@@ -40,8 +40,7 @@
       "X-XSS-Protection": "1; mode=block",
       "Referrer-Policy": "origin-when-cross-origin, strict-origin-when-cross-origin",
       "Content-Security-Policy": "default-src 'none'",
-      "X-GitHub-Request-Id": "CB13:833E:A1F759:BFE352:5DB3A151",
-      "Link": "<https://api.github.com/notifications?page=2>; rel=\"next\", <https://api.github.com/notifications?page=5>; rel=\"last\""
+      "X-GitHub-Request-Id": "CB13:833E:A1F759:BFE352:5DB3A151"
     }
   },
   "uuid": "ac22e3e2-f0d3-4ff1-af23-23e9c79c725c",

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/27-notifications.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/27-notifications.json
@@ -1,0 +1,47 @@
+{
+  "id": "ac22e3e2-f0d3-4ff1-af23-23e9c7915874",
+  "name": "notifications",
+  "request": {
+    "url": "/notifications",
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github+json"
+      },
+      "If-Modified-Since":{
+        "equalTo": "null"
+      }
+    }
+  },
+  "response": {
+    "status": 422,
+    "bodyFileName": "27-notifications.json",
+    "headers": {
+      "Date": "Wed, 20 Nov 2024 13:55:23 GMT",
+      "Content-Type": "application/json; charset=utf-8",
+      "X-OAuth-Scopes": "repo",
+      "X-Accepted-OAuth-Scopes": "notifications, repo",
+      "X-GitHub-Media-Type": "github.v3; format=json",
+      "x-github-api-version-selected": "2022-11-28",
+      "X-RateLimit-Limit": "5000",
+      "X-RateLimit-Remaining": "4992",
+      "X-RateLimit-Reset": "1732111985",
+      "X-RateLimit-Used": "8",
+      "X-RateLimit-Resource": "core",
+      "Access-Control-Expose-Headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset",
+      "Access-Control-Allow-Origin": "*",
+      "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",
+      "X-Frame-Options": "deny",
+      "X-Content-Type-Options": "nosniff",
+      "X-XSS-Protection": "0",
+      "Referrer-Policy": "origin-when-cross-origin, strict-origin-when-cross-origin",
+      "Content-Security-Policy": "default-src 'none'",
+      "Vary": "Accept-Encoding, Accept, X-Requested-With",
+      "Server": "github.com",
+      "X-GitHub-Request-Id": "052F:2E353B:3FE0C:42EBB:673DEA4B"
+    }
+  },
+  "uuid": "ac22e3e2-f0d3-4ff1-af23-23e9c7915874",
+  "persistent": true,
+  "insertionIndex": 26
+}


### PR DESCRIPTION
…-Since request header"

# Description

<!-- Describe your change here -->

fix GitHub notification interface return "Unable to parse If-Modified-Since request header" (fix #1985)

# Before submitting a PR:

- [ ] Changes must not break binary backwards compatibility. If you are unclear on how to make the change you think is needed while maintaining backward compatibility, [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [ ] Add JavaDocs and other comments explaining the behavior. 
- [ ] When adding or updating methods that fetch entities, add `@link` JavaDoc entries to the relevant documentation on https://docs.github.com/en/rest . 
- [ ] Add tests that cover any added or changed code. This generally requires capturing snapshot test data. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [ ] Run `mvn -D enable-ci clean install site` locally. If this command doesn't succeed, your change will not pass CI.
- [ ] Push your changes to a branch other than `main`. You will create your PR from that branch.

# When creating a PR: 

- [ ] Fill in the "Description" above with clear summary of the changes. This includes:
  - [ ] If this PR fixes one or more issues, include "Fixes #<issue number>" lines for each issue. 
  - [ ] Provide links to relevant documentation on https://docs.github.com/en/rest where possible. If not including links, explain why not.
- [ ] All lines of new code should be covered by tests as reported by code coverage. Any lines that are not covered must have PR comments explaining why they cannot be covered. For example, "Reaching this particular exception is hard and is not a particular common scenario."
- [ ] Enable "Allow edits from maintainers".
