### PR TITLE
Add ssh keys fields on meta API response

### DIFF
--- a/src/main/java/org/kohsuke/github/GHMeta.java
+++ b/src/main/java/org/kohsuke/github/GHMeta.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 // TODO: Auto-generated Javadoc
 /**
@@ -12,7 +13,8 @@ import java.util.List;
  *
  * @author Paulo Miguel Almeida
  * @see GitHub#getMeta() GitHub#getMeta()
- * @see <a href="https://developer.github.com/v3/meta/#meta">Get Meta</a>
+ * @see <a href="https://docs.github.com/en/rest/meta/meta?apiVersion=2022-11-28#get-github-meta-information">Get
+ *      Meta</a>
  */
 public class GHMeta {
 
@@ -24,6 +26,10 @@ public class GHMeta {
 
     @JsonProperty("verifiable_password_authentication")
     private boolean verifiablePasswordAuthentication;
+    @JsonProperty("ssh_key_fingerprints")
+    private Map<String, String> sshKeyFingerprints;
+    @JsonProperty("ssh_keys")
+    private List<String> sshKeys;
     private List<String> hooks;
     private List<String> git;
     private List<String> web;
@@ -41,6 +47,24 @@ public class GHMeta {
      */
     public boolean isVerifiablePasswordAuthentication() {
         return verifiablePasswordAuthentication;
+    }
+
+    /**
+     * Gets ssh key fingerprints.
+     *
+     * @return the ssh key fingerprints
+     */
+    public Map<String, String> getSshKeyFingerprints() {
+        return Collections.unmodifiableMap(sshKeyFingerprints);
+    }
+
+    /**
+     * Gets ssh keys.
+     *
+     * @return the ssh keys
+     */
+    public List<String> getSshKeys() {
+        return Collections.unmodifiableList(sshKeys);
     }
 
     /**

--- a/src/test/java/org/kohsuke/github/GitHubTest.java
+++ b/src/test/java/org/kohsuke/github/GitHubTest.java
@@ -283,6 +283,8 @@ public class GitHubTest extends AbstractGitHubWireMockTest {
     public void getMeta() throws IOException {
         GHMeta meta = gitHub.getMeta();
         assertThat(meta.isVerifiablePasswordAuthentication(), is(true));
+        assertThat(meta.getSshKeyFingerprints().size(), equalTo(4));
+        assertThat(meta.getSshKeys().size(), equalTo(3));
         assertThat(meta.getApi().size(), equalTo(19));
         assertThat(meta.getGit().size(), equalTo(36));
         assertThat(meta.getHooks().size(), equalTo(4));

--- a/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/getMeta/__files/1-meta.json
+++ b/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/getMeta/__files/1-meta.json
@@ -1,5 +1,16 @@
 {
   "verifiable_password_authentication": true,
+  "ssh_key_fingerprints": {
+    "SHA256_RSA": 1234567890,
+    "SHA256_DSA": 1234567890,
+    "SHA256_ECDSA": 1234567890,
+    "SHA256_ED25519": 1234567890
+  },
+  "ssh_keys": [
+    "ssh-ed25519 ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+    "ecdsa-sha2-nistp256 ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+    "ssh-rsa ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+  ],
   "hooks": [
     "192.30.252.0/22",
     "185.199.108.0/22",


### PR DESCRIPTION
# Description

GitHub added in 2022 those fields on the meta API

I have an application I need to retrieve those public keys have a manual verification before closing repositories (using Apache Mina)

# Before submitting a PR:

- [x] Changes must not break binary backwards compatibility. If you are unclear on how to make the change you think is needed while maintaining backward compatibility, [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [x] Add JavaDocs and other comments explaining the behavior. 
- [x] When adding or updating methods that fetch entities, add `@link` JavaDoc entries to the relevant documentation on https://docs.github.com/en/rest . 
- [x] Add tests that cover any added or changed code. This generally requires capturing snapshot test data. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [x] Run `mvn -D enable-ci clean install site` locally. If this command doesn't succeed, your change will not pass CI.
- [x] Push your changes to a branch other than `main`. You will create your PR from that branch.

# When creating a PR: 

- [x] Fill in the "Description" above with clear summary of the changes. This includes:
  - [ ] If this PR fixes one or more issues, include "Fixes #<issue number>" lines for each issue. 
  - [x] Provide links to relevant documentation on https://docs.github.com/en/rest where possible. If not including links, explain why not.
- [x] All lines of new code should be covered by tests as reported by code coverage. Any lines that are not covered must have PR comments explaining why they cannot be covered. For example, "Reaching this particular exception is hard and is not a particular common scenario."
- [x] Enable "Allow edits from maintainers".
