### PR TITLE
FEAT: Implement enabling auto merge for PR by GraphQL

### DIFF
--- a/src/main/java/org/kohsuke/github/GHPullRequest.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequest.java
@@ -23,8 +23,11 @@
  */
 package org.kohsuke.github;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.lang3.StringUtils;
+import org.kohsuke.github.graphql.response.GHGraphQLResponse;
 
 import java.io.IOException;
 import java.net.URL;
@@ -627,6 +630,187 @@ public class GHPullRequest extends GHIssue implements Refreshable {
         SQUASH,
         /** The rebase. */
         REBASE
+    }
+
+    /**
+     * Get pull request id for GraphQL
+     *
+     * @return The pull request id for GraphQL
+     *
+     */
+    public String getGraphqlPullRequestId() throws IOException {
+        if (owner == null) {
+            throw new IllegalStateException("Repository owner is required to get the pull request ID");
+        }
+        String repositoryName = owner.getName();
+        String ownerName = owner.getOwnerName();
+
+        String graphqlBody = String.format(
+                "query GetPullRequestID { repository(name: \"%s\", owner: \"%s\") { pullRequest(number: %d) { id } } }",
+                repositoryName,
+                ownerName,
+                number);
+
+        GHGraphQLResponse<GetGraphqlPullRequestIdResponse> response = root().createGraphQLRequest(graphqlBody)
+                .fetchGraphQLResponse(GetGraphqlPullRequestIdResponse.class);
+
+        if (!response.isSuccessful()) {
+            throw new IOException("Failed to get graphql pull request id: " + response.getErrorMessages());
+        }
+
+        return response.getData().getId();
+    }
+
+    /**
+     * The response from the GraphQL query to get the pull request ID. Minimum required fields are included.
+     */
+    private static class GetGraphqlPullRequestIdResponse {
+        private final PullRequestOwnerRepository repository;
+
+        @JsonCreator
+        public GetGraphqlPullRequestIdResponse(@JsonProperty("repository") PullRequestOwnerRepository repository) {
+            this.repository = repository;
+        }
+
+        public String getId() {
+            return repository.getId();
+        }
+
+        private static class PullRequestOwnerRepository {
+            private final GraphQLPullRequest pullRequest;
+
+            @JsonCreator
+            public PullRequestOwnerRepository(@JsonProperty("pullRequest") GraphQLPullRequest pullRequest) {
+                this.pullRequest = pullRequest;
+            }
+
+            public String getId() {
+                return pullRequest.getId();
+            }
+
+            private static class GraphQLPullRequest {
+                private final String id;
+
+                @JsonCreator
+                public GraphQLPullRequest(@JsonProperty("id") String id) {
+                    this.id = id;
+                }
+
+                public String getId() {
+                    return id;
+                }
+            }
+        }
+    }
+
+    /**
+     * Request to enable auto merge for a pull request.
+     *
+     * @param authorEmail
+     *            The email address to associate with this merge.
+     * @param clientMutationId
+     *            A unique identifier for the client performing the mutation.
+     * @param commitBody
+     *            Commit body to use for the commit when the PR is mergable; if omitted, a default message will be used.
+     *            NOTE: when merging with a merge queue any input value for commit message is ignored.
+     * @param commitHeadline
+     *            Commit headline to use for the commit when the PR is mergable; if omitted, a default message will be
+     *            used. NOTE: when merging with a merge queue any input value for commit headline is ignored.
+     * @param expectedHeadOid
+     *            The expected head OID of the pull request.
+     * @param mergeMethod
+     *            The merge method to use. If omitted, defaults to `MERGE`. NOTE: when merging with a merge queue any
+     *            input value for merge method is ignored.
+     * @throws IOException
+     *             the io exception
+     */
+    public void requestEnableAutoMerge(String authorEmail,
+            String clientMutationId,
+            String commitBody,
+            String commitHeadline,
+            Integer expectedHeadOid,
+            MergeMethod mergeMethod) throws IOException {
+
+        StringBuilder inputBuilder = new StringBuilder();
+        inputBuilder.append(" pullRequestId: \"").append(getGraphqlPullRequestId()).append("\"");
+
+        if (authorEmail != null) {
+            inputBuilder.append(" authorEmail: \"").append(authorEmail).append("\"");
+        }
+        if (clientMutationId != null) {
+            inputBuilder.append(" clientMutationId: \"").append(clientMutationId).append("\"");
+        }
+        if (commitBody != null) {
+            inputBuilder.append(" commitBody: \"").append(commitBody).append("\"");
+        }
+        if (commitHeadline != null) {
+            inputBuilder.append(" commitHeadline: \"").append(commitHeadline).append("\"");
+        }
+        if (expectedHeadOid != null) {
+            inputBuilder.append(" expectedHeadOid: ").append(expectedHeadOid);
+        }
+        if (mergeMethod != null) {
+            inputBuilder.append(" mergeMethod: ").append(mergeMethod);
+        }
+
+        String graphqlBody = "mutation EnableAutoMerge { enablePullRequestAutoMerge(input: {" + inputBuilder + "}) { "
+                + "pullRequest { id } } }";
+
+        GHGraphQLResponse<EnablePullRequestAutoMergeResponse> response = root().createGraphQLRequest(graphqlBody)
+                .fetchGraphQLResponse(EnablePullRequestAutoMergeResponse.class);
+
+        if (!response.isSuccessful()) {
+            throw new IOException("Failed to enable auto merge: " + response.getErrorMessages());
+        }
+
+        refresh();
+    }
+
+    /**
+     * The response from the GraphQL query to enable auto merge for a pull request. Minimum required fields are
+     * included.
+     */
+    private static class EnablePullRequestAutoMergeResponse {
+        private final EnablePullRequestAutoMerge enablePullRequestAutoMerge;
+
+        @JsonCreator
+        public EnablePullRequestAutoMergeResponse(
+                @JsonProperty("enablePullRequestAutoMerge") EnablePullRequestAutoMerge enablePullRequestAutoMerge) {
+            this.enablePullRequestAutoMerge = enablePullRequestAutoMerge;
+        }
+
+        public String getId() {
+            return enablePullRequestAutoMerge.getId();
+        }
+
+        private static class EnablePullRequestAutoMerge {
+
+            private final EnablePullRequestAutoMergePullRequest pullRequest;
+
+            @JsonCreator
+            public EnablePullRequestAutoMerge(
+                    @JsonProperty("pullRequest") EnablePullRequestAutoMergePullRequest autoMergeRequest) {
+                this.pullRequest = autoMergeRequest;
+            }
+
+            public String getId() {
+                return pullRequest.getId();
+            }
+
+            private static class EnablePullRequestAutoMergePullRequest {
+
+                private final String id;
+
+                @JsonCreator
+                public EnablePullRequestAutoMergePullRequest(@JsonProperty("id") String id) {
+                    this.id = id;
+                }
+
+                public String getId() {
+                    return id;
+                }
+            }
+        }
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GitHub.java
+++ b/src/main/java/org/kohsuke/github/GitHub.java
@@ -1300,6 +1300,18 @@ public class GitHub {
     }
 
     /**
+     * Creates a request to GitHub GraphQL API.
+     *
+     * @param query
+     *            the query for the GraphQL
+     * @return the requester
+     */
+    @Nonnull
+    Requester createGraphQLRequest(String query) {
+        return createRequest().method("POST").with("query", query).withUrlPath("/graphql");
+    }
+
+    /**
      * Intern.
      *
      * @param user

--- a/src/main/java/org/kohsuke/github/GitHubResponse.java
+++ b/src/main/java/org/kohsuke/github/GitHubResponse.java
@@ -1,10 +1,10 @@
 package org.kohsuke.github;
 
 import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.InjectableValues;
-import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.*;
 import org.apache.commons.io.IOUtils;
 import org.kohsuke.github.connector.GitHubConnectorResponse;
+import org.kohsuke.github.graphql.response.GHGraphQLResponse;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -129,6 +129,43 @@ class GitHubResponse<T> {
         String data = getBodyAsString(connectorResponse);
         try {
             return GitHubClient.getMappingObjectReader(connectorResponse).withValueToUpdate(instance).readValue(data);
+        } catch (JsonMappingException | JsonParseException e) {
+            String message = "Failed to deserialize: " + data;
+            LOGGER.log(Level.FINE, message);
+            throw e;
+        }
+    }
+
+    /**
+     * Parses a {@link GitHubConnectorResponse} body into a new instance of {@code GHGraphQLResponse<T>}.
+     * @param <T>
+     *       the type
+     * @param connectorResponse the response info to parse.
+     * @param type
+     *      the type to be constructed in GraphQLResponse.
+     * @return GHGraphQLResponse
+     *
+     * @throws IOException
+     *           if there is an I/O Exception.
+     */
+    @CheckForNull
+    static <T> GHGraphQLResponse<T> parseGraphQLBody(GitHubConnectorResponse connectorResponse, Class<T> type)
+            throws IOException {
+        if (connectorResponse.statusCode() == HTTP_NO_CONTENT) {
+            if (type != null && type.isArray()) {
+                T emptyArray = type.cast(Array.newInstance(type.getComponentType(), 0));
+                return new GHGraphQLResponse<>(emptyArray, null);
+            } else {
+                return new GHGraphQLResponse<>(null, null);
+            }
+        }
+
+        String data = getBodyAsString(connectorResponse);
+        try {
+            ObjectReader objectReader = GitHubClient.getMappingObjectReader(connectorResponse);
+            JavaType targetType = objectReader.getTypeFactory().constructParametricType(GHGraphQLResponse.class, type);
+            ObjectReader targetReader = objectReader.forType(targetType);
+            return targetReader.readValue(data);
         } catch (JsonMappingException | JsonParseException e) {
             String message = "Failed to deserialize: " + data;
             LOGGER.log(Level.FINE, message);

--- a/src/main/java/org/kohsuke/github/Requester.java
+++ b/src/main/java/org/kohsuke/github/Requester.java
@@ -27,6 +27,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import org.apache.commons.io.IOUtils;
 import org.kohsuke.github.connector.GitHubConnectorResponse;
 import org.kohsuke.github.function.InputStreamFunction;
+import org.kohsuke.github.graphql.response.GHGraphQLResponse;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -100,6 +101,21 @@ class Requester extends GitHubRequest.Builder<Requester> {
     public <T> T fetchInto(@Nonnull T existingInstance) throws IOException {
         return client
                 .sendRequest(this, (connectorResponse) -> GitHubResponse.parseBody(connectorResponse, existingInstance))
+                .body();
+    }
+
+    /**
+     * Sends a request and parses the response into the given type via databinding in graphQL response.
+     * @param <T>
+     *       the type parameter
+     * @param type
+     *           the type
+     * @return an instance of {@code GHGraphQLResponse<T>}
+     * @throws IOException
+     *          if the server returns 4xx/5xx responses.
+     */
+    public <T> GHGraphQLResponse<T> fetchGraphQLResponse(@Nonnull Class<T> type) throws IOException {
+        return client.sendRequest(this, connectorResponse -> GitHubResponse.parseGraphQLBody(connectorResponse, type))
                 .body();
     }
 

--- a/src/main/java/org/kohsuke/github/graphql/response/GHGraphQLResponse.java
+++ b/src/main/java/org/kohsuke/github/graphql/response/GHGraphQLResponse.java
@@ -1,0 +1,66 @@
+package org.kohsuke.github.graphql.response;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * A response of GraphQL.
+ * <p>
+ * This class is used to parse the response of GraphQL.
+ * </p>
+ *
+ * @param <T> the type of data
+ */
+public class GHGraphQLResponse<T> {
+
+    private final T data;
+
+    private final List<GHGraphQLError> errors;
+
+    @JsonCreator
+    public GHGraphQLResponse(@JsonProperty("data") T data, @JsonProperty("errors") List<GHGraphQLError> errors) {
+        this.data = data;
+        this.errors = errors;
+    }
+
+    public Boolean isSuccessful() {
+        return errors == null || errors.isEmpty();
+    }
+
+    public T getData() {
+        if (!isSuccessful()) {
+            throw new RuntimeException("This response is Errors occurred response");
+        }
+
+        return data;
+    }
+
+    public List<String> getErrorMessages() {
+        if (isSuccessful()) {
+            throw new RuntimeException("No errors occurred");
+        }
+
+        return errors.stream().map(GHGraphQLError::getErrorMessage).collect(Collectors.toList());
+    }
+
+    /**
+     * A error of GraphQL response.
+     * Minimum implementation for GraphQL error.
+     */
+    private static class GHGraphQLError {
+
+        private final String errorMessage;
+
+        @JsonCreator
+        public GHGraphQLError(@JsonProperty("message") String errorMessage) {
+            this.errorMessage = errorMessage;
+        }
+
+        public String getErrorMessage() {
+            return errorMessage;
+        }
+    }
+}


### PR DESCRIPTION
# Description

<!-- Describe your change here -->
- Fixed #2039  

<br>

Implement to enable Auto merge for PR by GraphQL.
- Implement general GraphQL request, response support for the feature.

<br>

Test will be added when I get permissions to access the test repository.



# Before submitting a PR:

- [X] Changes must not break binary backwards compatibility. If you are unclear on how to make the change you think is needed while maintaining backward compatibility, [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [X] Add JavaDocs and other comments explaining the behavior. 
- [ ] When adding or updating methods that fetch entities, add `@link` JavaDoc entries to the relevant documentation on https://docs.github.com/en/rest . 
- [ ] Add tests that cover any added or changed code. This generally requires capturing snapshot test data. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [ ] Run `mvn -D enable-ci clean install site` locally. If this command doesn't succeed, your change will not pass CI.
- [X] Push your changes to a branch other than `main`. You will create your PR from that branch.

# When creating a PR: 

- [X] Fill in the "Description" above with clear summary of the changes. This includes:
  - [X] If this PR fixes one or more issues, include "Fixes #<issue number>" lines for each issue. 
  - [X] Provide links to relevant documentation on https://docs.github.com/en/rest where possible. If not including links, explain why not.
- [ ] All lines of new code should be covered by tests as reported by code coverage. Any lines that are not covered must have PR comments explaining why they cannot be covered. For example, "Reaching this particular exception is hard and is not a particular common scenario."
- [X] Enable "Allow edits from maintainers".
