### PR TITLE
Add an option to avoid buffered response stream.

### DIFF
--- a/src/main/java/org/kohsuke/github/GHArtifact.java
+++ b/src/main/java/org/kohsuke/github/GHArtifact.java
@@ -115,7 +115,11 @@ public class GHArtifact extends GHObject {
     public <T> T download(InputStreamFunction<T> streamFunction) throws IOException {
         requireNonNull(streamFunction, "Stream function must not be null");
 
-        return root().createRequest().method("GET").withUrlPath(getApiRoute(), "zip").fetchStream(streamFunction);
+        return root().createRequest()
+                .method("GET")
+                .withUrlPath(getApiRoute(), "zip")
+                .avoidBufferedResponseStream()
+                .fetchStream(streamFunction);
     }
 
     private String getApiRoute() {

--- a/src/main/java/org/kohsuke/github/GitHubRequest.java
+++ b/src/main/java/org/kohsuke/github/GitHubRequest.java
@@ -51,6 +51,7 @@ public class GitHubRequest implements GitHubConnectorRequest {
     private final RateLimitTarget rateLimitTarget;
     private final byte[] body;
     private final boolean forceBody;
+    private final boolean avoidBufferedResponseStream;
 
     private final URL url;
 
@@ -63,7 +64,8 @@ public class GitHubRequest implements GitHubConnectorRequest {
             @Nonnull String method,
             @Nonnull RateLimitTarget rateLimitTarget,
             @CheckForNull byte[] body,
-            boolean forceBody) {
+            boolean forceBody,
+            boolean avoidBufferedResponseStream) {
         this.args = Collections.unmodifiableList(new ArrayList<>(args));
         TreeMap<String, List<String>> caseInsensitiveMap = new TreeMap<>(nullableCaseInsensitiveComparator);
         for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
@@ -77,6 +79,7 @@ public class GitHubRequest implements GitHubConnectorRequest {
         this.rateLimitTarget = rateLimitTarget;
         this.body = body;
         this.forceBody = forceBody;
+        this.avoidBufferedResponseStream = avoidBufferedResponseStream;
         String tailApiUrl = buildTailApiUrl();
         url = getApiURL(apiUrl, tailApiUrl);
     }
@@ -270,6 +273,14 @@ public class GitHubRequest implements GitHubConnectorRequest {
     }
 
     /**
+     * Whether the response to this request should avoid buffered stream or not.
+     */
+    @Override
+    public boolean avoidBufferedResponseStream() {
+        return avoidBufferedResponseStream;
+    }
+
+    /**
      * Create a {@link Builder} from this request. Initial values of the builder will be the same as this
      * {@link GitHubRequest}.
      *
@@ -354,6 +365,7 @@ public class GitHubRequest implements GitHubConnectorRequest {
 
         private byte[] body;
         private boolean forceBody;
+        private boolean avoidBufferedResponseStream;
 
         /**
          * Create a new {@link GitHubRequest.Builder}
@@ -410,7 +422,8 @@ public class GitHubRequest implements GitHubConnectorRequest {
                     method,
                     rateLimitTarget,
                     body,
-                    forceBody);
+                    forceBody,
+                    avoidBufferedResponseStream);
         }
 
         /**
@@ -798,6 +811,17 @@ public class GitHubRequest implements GitHubConnectorRequest {
          */
         public B inBody() {
             forceBody = true;
+            return (B) this;
+        }
+
+        /**
+         * We cache response stream into buffer by default, but some responses can be huge so we should avoid that.
+         * Setting this flag indicates that we should avoid buffered stream response.
+         *
+         * @return the request builder
+         */
+        public B avoidBufferedResponseStream() {
+            avoidBufferedResponseStream = true;
             return (B) this;
         }
     }

--- a/src/main/java/org/kohsuke/github/connector/GitHubConnectorRequest.java
+++ b/src/main/java/org/kohsuke/github/connector/GitHubConnectorRequest.java
@@ -81,4 +81,13 @@ public interface GitHubConnectorRequest {
      * @return true, if the body is not null. Otherwise, false.
      */
     boolean hasBody();
+
+    /**
+     * Whether the response stream to this request is not buffered. It is used to avoid huge response caching.
+     *
+     * @return true, if the response stream is not buffered.
+     */
+    default boolean avoidBufferedResponseStream() {
+        return false;
+    }
 }


### PR DESCRIPTION
context: #1405

GHArtifact.download() now explicitly sets this option to make response stream non-buffered.

# Description

<!-- Describe your change here -->

# Before submitting a PR:

- [ ] Changes must not break binary backwards compatibility. If you are unclear on how to make the change you think is needed while maintaining backward compatibility, [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [ ] Add JavaDocs and other comments explaining the behavior. 
- [ ] When adding or updating methods that fetch entities, add `@link` JavaDoc entries to the relevant documentation on https://docs.github.com/en/rest . 
- [ ] Add tests that cover any added or changed code. This generally requires capturing snapshot test data. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [ ] Run `mvn -D enable-ci clean install site` locally. If this command doesn't succeed, your change will not pass CI.
- [ ] Push your changes to a branch other than `main`. You will create your PR from that branch.

# When creating a PR: 

- [ ] Fill in the "Description" above with clear summary of the changes. This includes:
  - [ ] If this PR fixes one or more issues, include "Fixes #<issue number>" lines for each issue. 
  - [ ] Provide links to relevant documentation on https://docs.github.com/en/rest where possible. If not including links, explain why not.
- [ ] All lines of new code should be covered by tests as reported by code coverage. Any lines that are not covered must have PR comments explaining why they cannot be covered. For example, "Reaching this particular exception is hard and is not a particular common scenario."
- [ ] Enable "Allow edits from maintainers".
