### PR TITLE
Add side and start_side Parameters to Create Review Comment

### DIFF
--- a/src/main/java/org/kohsuke/github/GHPullRequestReviewCommentBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequestReviewCommentBuilder.java
@@ -142,8 +142,8 @@ public class GHPullRequestReviewCommentBuilder {
      */
     public GHPullRequestReviewCommentBuilder sides(GHPullRequestReviewComment.Side startSide,
             GHPullRequestReviewComment.Side endSide) {
-        builder.with("start_side", startSide.toString().toLowerCase());
-        builder.with("side", endSide.toString().toLowerCase());
+        builder.with("start_side", startSide);
+        builder.with("side", endSide);
         return this;
     }
 

--- a/src/main/java/org/kohsuke/github/GHPullRequestReviewCommentBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequestReviewCommentBuilder.java
@@ -111,6 +111,43 @@ public class GHPullRequestReviewCommentBuilder {
     }
 
     /**
+     * The side of the diff in the pull request that the comment applies to.
+     * <p>
+     * {@link #side(GHPullRequestReviewComment.Side)} and
+     * {@link #sides(GHPullRequestReviewComment.Side, GHPullRequestReviewComment.Side)} will overwrite each other's
+     * values.
+     *
+     * @param side
+     *            side of the diff to which the comment applies
+     * @return the gh pull request review comment builder
+     */
+    public GHPullRequestReviewCommentBuilder side(GHPullRequestReviewComment.Side side) {
+        builder.with("side", side.toString().toLowerCase());
+        builder.remove("start_side");
+        return this;
+    }
+
+    /**
+     * The sides of the diff in the pull request that the comment applies to.
+     * <p>
+     * {@link #side(GHPullRequestReviewComment.Side)} and
+     * {@link #sides(GHPullRequestReviewComment.Side, GHPullRequestReviewComment.Side)} will overwrite each other's
+     * values.
+     *
+     * @param startSide
+     *            side of the diff to which the start of the comment applies
+     * @param endSide
+     *            side of the diff to which the end of the comment applies
+     * @return the gh pull request review comment builder
+     */
+    public GHPullRequestReviewCommentBuilder sides(GHPullRequestReviewComment.Side startSide,
+            GHPullRequestReviewComment.Side endSide) {
+        builder.with("start_side", startSide.toString().toLowerCase());
+        builder.with("side", endSide.toString().toLowerCase());
+        return this;
+    }
+
+    /**
      * Create gh pull request review comment.
      *
      * @return the gh pull request review comment builder

--- a/src/main/java/org/kohsuke/github/GHPullRequestReviewCommentBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequestReviewCommentBuilder.java
@@ -122,7 +122,7 @@ public class GHPullRequestReviewCommentBuilder {
      * @return the gh pull request review comment builder
      */
     public GHPullRequestReviewCommentBuilder side(GHPullRequestReviewComment.Side side) {
-        builder.with("side", side.toString().toLowerCase());
+        builder.with("side", side);
         builder.remove("start_side");
         return this;
     }

--- a/src/test/java/org/kohsuke/github/GHPullRequestTest.java
+++ b/src/test/java/org/kohsuke/github/GHPullRequestTest.java
@@ -25,6 +25,8 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.kohsuke.github.GHPullRequestReviewComment.Side.LEFT;
+import static org.kohsuke.github.GHPullRequestReviewComment.Side.RIGHT;
 
 // TODO: Auto-generated Javadoc
 /**
@@ -337,12 +339,14 @@ public class GHPullRequestTest extends AbstractGitHubWireMockTest {
                     .body("A single line review comment")
                     .path("README.md")
                     .line(2)
+                    .side(RIGHT)
                     .create();
             p.createReviewComment()
                     .commitId(p.getHead().getSha())
                     .body("A multiline review comment")
                     .path("README.md")
                     .lines(2, 3)
+                    .sides(RIGHT, RIGHT)
                     .create();
             List<GHPullRequestReviewComment> comments = p.listReviewComments().toList();
             assertThat(comments.size(), equalTo(3));
@@ -362,7 +366,7 @@ public class GHPullRequestTest extends AbstractGitHubWireMockTest {
             assertThat(comment.getStartSide(), equalTo(GHPullRequestReviewComment.Side.UNKNOWN));
             assertThat(comment.getLine(), equalTo(1));
             assertThat(comment.getOriginalLine(), equalTo(1));
-            assertThat(comment.getSide(), equalTo(GHPullRequestReviewComment.Side.LEFT));
+            assertThat(comment.getSide(), equalTo(LEFT));
             assertThat(comment.getPullRequestUrl(), notNullValue());
             assertThat(comment.getPullRequestUrl().toString(), containsString("hub4j-test-org/github-api/pulls/"));
             assertThat(comment.getBodyHtml(), nullValue());
@@ -375,11 +379,14 @@ public class GHPullRequestTest extends AbstractGitHubWireMockTest {
             comment = comments.get(1);
             assertThat(comment.getBody(), equalTo("A single line review comment"));
             assertThat(comment.getLine(), equalTo(2));
+            assertThat(comment.getSide(), equalTo(RIGHT));
 
             comment = comments.get(2);
             assertThat(comment.getBody(), equalTo("A multiline review comment"));
             assertThat(comment.getStartLine(), equalTo(2));
             assertThat(comment.getLine(), equalTo(3));
+            assertThat(comment.getStartSide(), equalTo(RIGHT));
+            assertThat(comment.getSide(), equalTo(RIGHT));
 
             comment.createReaction(ReactionContent.EYES);
             GHReaction toBeRemoved = comment.createReaction(ReactionContent.CONFUSED);

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviewComments/mappings/7-r_h_g_pulls_484_comments.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviewComments/mappings/7-r_h_g_pulls_484_comments.json
@@ -11,7 +11,7 @@
     },
     "bodyPatterns": [
       {
-        "equalToJson": "{\"path\":\"README.md\",\"line\":2,\"body\":\"A single line review comment\",\"commit_id\":\"07374fe73aff1c2024a8d4114b32406c7a8e89b7\"}",
+        "equalToJson": "{\"path\":\"README.md\",\"side\":\"right\",\"line\":2,\"body\":\"A single line review comment\",\"commit_id\":\"07374fe73aff1c2024a8d4114b32406c7a8e89b7\"}",
         "ignoreArrayOrder": true,
         "ignoreExtraElements": false
       }

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviewComments/mappings/8-r_h_g_pulls_484_comments.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviewComments/mappings/8-r_h_g_pulls_484_comments.json
@@ -11,7 +11,7 @@
     },
     "bodyPatterns": [
       {
-        "equalToJson": "{\"path\":\"README.md\",\"line\":3,\"start_line\":2,\"body\":\"A multiline review comment\",\"commit_id\":\"07374fe73aff1c2024a8d4114b32406c7a8e89b7\"}",
+        "equalToJson": "{\"path\":\"README.md\",\"side\":\"right\",\"start_side\":\"right\",\"line\":3,\"start_line\":2,\"body\":\"A multiline review comment\",\"commit_id\":\"07374fe73aff1c2024a8d4114b32406c7a8e89b7\"}",
         "ignoreArrayOrder": true,
         "ignoreExtraElements": false
       }


### PR DESCRIPTION
# Description

Follows existing pattern from line and start_line.

https://docs.github.com/en/rest/pulls/comments?apiVersion=2022-11-28#create-a-review-comment-for-a-pull-request

# Before submitting a PR:

- [x] Changes must not break binary backwards compatibility. If you are unclear on how to make the change you think is needed while maintaining backward compatibility, [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [x] Add JavaDocs and other comments explaining the behavior. 
- [x] When adding or updating methods that fetch entities, add `@link` JavaDoc entries to the relevant documentation on https://docs.github.com/en/rest . 
- [x] Add tests that cover any added or changed code. This generally requires capturing snapshot test data. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [x] Run `mvn -D enable-ci clean install site` locally. If this command doesn't succeed, your change will not pass CI.
- [x] Push your changes to a branch other than `main`. You will create your PR from that branch.

# When creating a PR: 

- [x] Fill in the "Description" above with clear summary of the changes. This includes:
  - [x] If this PR fixes one or more issues, include "Fixes #<issue number>" lines for each issue. 
  - [x] Provide links to relevant documentation on https://docs.github.com/en/rest where possible. If not including links, explain why not.
- [x] All lines of new code should be covered by tests as reported by code coverage. Any lines that are not covered must have PR comments explaining why they cannot be covered. For example, "Reaching this particular exception is hard and is not a particular common scenario."
- [x] Enable "Allow edits from maintainers".
