### PR TITLE
Migrate legacy date-time api to new date-time api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,10 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.infradna.tool</groupId>
       <artifactId>bridge-method-annotation</artifactId>
       <version>1.30</version>
@@ -636,7 +640,7 @@
       <!--
       This plugin is used to generate AOT metadata during tests so that it can be
       compared against those in META-INF/native-image/org.kohsuke/github-api/*.
-      The tests are start with the name "Aot..." 
+      The tests are start with the name "Aot..."
       -->
       <plugin>
         <groupId>org.springframework.boot</groupId>

--- a/src/main/java/org/kohsuke/github/GHApp.java
+++ b/src/main/java/org/kohsuke/github/GHApp.java
@@ -5,8 +5,8 @@ import org.kohsuke.github.internal.EnumUtils;
 
 import java.io.IOException;
 import java.net.URL;
+import java.time.Instant;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -158,10 +158,10 @@ public class GHApp extends GHObject {
      * @return a list of App installations since a given time.
      * @see <a href="https://developer.github.com/v3/apps/#list-installations">List installations</a>
      */
-    public PagedIterable<GHAppInstallation> listInstallations(final Date since) {
+    public PagedIterable<GHAppInstallation> listInstallations(final Instant since) {
         Requester requester = root().createRequest().withUrlPath("/app/installations");
         if (since != null) {
-            requester.with("since", GitHubClient.printDate(since));
+            requester.with("since", GitHubClient.printInstant(since));
         }
         return requester.toIterable(GHAppInstallation[].class, null);
     }

--- a/src/main/java/org/kohsuke/github/GHAppInstallation.java
+++ b/src/main/java/org/kohsuke/github/GHAppInstallation.java
@@ -6,8 +6,8 @@ import org.kohsuke.github.internal.EnumUtils;
 
 import java.io.IOException;
 import java.net.URL;
+import java.time.Instant;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -189,8 +189,8 @@ public class GHAppInstallation extends GHObject {
      *
      * @return the suspended at
      */
-    public Date getSuspendedAt() {
-        return GitHubClient.parseDate(suspendedAt);
+    public Instant getSuspendedAt() {
+        return GitHubClient.parseInstant(suspendedAt);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHAppInstallationToken.java
+++ b/src/main/java/org/kohsuke/github/GHAppInstallationToken.java
@@ -1,5 +1,6 @@
 package org.kohsuke.github;
 
+import java.time.Instant;
 import java.util.*;
 
 // TODO: Auto-generated Javadoc
@@ -66,7 +67,7 @@ public class GHAppInstallationToken extends GitHubInteractiveObject {
      *
      * @return date when this token expires
      */
-    public Date getExpiresAt() {
-        return GitHubClient.parseDate(expires_at);
+    public Instant getExpiresAt() {
+        return GitHubClient.parseInstant(expires_at);
     }
 }

--- a/src/main/java/org/kohsuke/github/GHArtifact.java
+++ b/src/main/java/org/kohsuke/github/GHArtifact.java
@@ -7,7 +7,7 @@ import org.kohsuke.github.function.InputStreamFunction;
 
 import java.io.IOException;
 import java.net.URL;
-import java.util.Date;
+import java.time.Instant;
 import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
@@ -77,8 +77,8 @@ public class GHArtifact extends GHObject {
      *
      * @return the date of expiration
      */
-    public Date getExpiresAt() {
-        return GitHubClient.parseDate(expiresAt);
+    public Instant getExpiresAt() {
+        return GitHubClient.parseInstant(expiresAt);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHCheckRun.java
+++ b/src/main/java/org/kohsuke/github/GHCheckRun.java
@@ -7,9 +7,9 @@ import org.kohsuke.github.internal.EnumUtils;
 
 import java.io.IOException;
 import java.net.URL;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 
@@ -269,8 +269,8 @@ public class GHCheckRun extends GHObject {
      *
      * @return Timestamp of the start time
      */
-    public Date getStartedAt() {
-        return GitHubClient.parseDate(startedAt);
+    public Instant getStartedAt() {
+        return GitHubClient.parseInstant(startedAt);
     }
 
     /**
@@ -278,8 +278,8 @@ public class GHCheckRun extends GHObject {
      *
      * @return Timestamp of the completed time
      */
-    public Date getCompletedAt() {
-        return GitHubClient.parseDate(completedAt);
+    public Instant getCompletedAt() {
+        return GitHubClient.parseInstant(completedAt);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHCheckRunBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHCheckRunBuilder.java
@@ -30,8 +30,8 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Collections;
-import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
@@ -172,9 +172,9 @@ public final class GHCheckRunBuilder {
      *            the started at
      * @return the GH check run builder
      */
-    public @NonNull GHCheckRunBuilder withStartedAt(@CheckForNull Date startedAt) {
+    public @NonNull GHCheckRunBuilder withStartedAt(@CheckForNull Instant startedAt) {
         if (startedAt != null) {
-            requester.with("started_at", GitHubClient.printDate(startedAt));
+            requester.with("started_at", GitHubClient.printInstant(startedAt));
         }
         return this;
     }
@@ -186,9 +186,9 @@ public final class GHCheckRunBuilder {
      *            the completed at
      * @return the GH check run builder
      */
-    public @NonNull GHCheckRunBuilder withCompletedAt(@CheckForNull Date completedAt) {
+    public @NonNull GHCheckRunBuilder withCompletedAt(@CheckForNull Instant completedAt) {
         if (completedAt != null) {
-            requester.with("completed_at", GitHubClient.printDate(completedAt));
+            requester.with("completed_at", GitHubClient.printInstant(completedAt));
         }
         return this;
     }

--- a/src/main/java/org/kohsuke/github/GHCheckSuite.java
+++ b/src/main/java/org/kohsuke/github/GHCheckSuite.java
@@ -5,9 +5,9 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
 import java.net.URL;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 
 // TODO: Auto-generated Javadoc
@@ -257,8 +257,8 @@ public class GHCheckSuite extends GHObject {
          *
          * @return timestamp of the commit
          */
-        public Date getTimestamp() {
-            return GitHubClient.parseDate(timestamp);
+        public Instant getTimestamp() {
+            return GitHubClient.parseInstant(timestamp);
         }
 
         /**

--- a/src/main/java/org/kohsuke/github/GHCommit.java
+++ b/src/main/java/org/kohsuke/github/GHCommit.java
@@ -4,10 +4,10 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
 import java.net.URL;
+import java.time.Instant;
 import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 
 // TODO: Auto-generated Javadoc
@@ -471,7 +471,7 @@ public class GHCommit {
      * @throws IOException
      *             if the information was not already fetched and an attempt at fetching the information failed.
      */
-    public Date getAuthoredDate() throws IOException {
+    public Instant getAuthoredDate() throws IOException {
         return getCommitShortInfo().getAuthoredDate();
     }
 
@@ -494,7 +494,7 @@ public class GHCommit {
      * @throws IOException
      *             if the information was not already fetched and an attempt at fetching the information failed.
      */
-    public Date getCommitDate() throws IOException {
+    public Instant getCommitDate() throws IOException {
         return getCommitShortInfo().getCommitDate();
     }
 

--- a/src/main/java/org/kohsuke/github/GHCommitBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHCommitBuilder.java
@@ -1,12 +1,9 @@
 package org.kohsuke.github;
 
 import java.io.IOException;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
-import java.util.TimeZone;
 
 // TODO: Auto-generated Javadoc
 /**
@@ -23,13 +20,10 @@ public class GHCommitBuilder {
         private final String email;
         private final String date;
 
-        private UserInfo(String name, String email, Date date) {
+        private UserInfo(String name, String email, Instant date) {
             this.name = name;
             this.email = email;
-            TimeZone tz = TimeZone.getTimeZone("UTC");
-            DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
-            df.setTimeZone(tz);
-            this.date = df.format((date != null) ? date : new Date());
+            this.date = GitHubClient.printInstant(date);
         }
     }
 
@@ -91,7 +85,7 @@ public class GHCommitBuilder {
      *            the date
      * @return the gh commit builder
      */
-    public GHCommitBuilder author(String name, String email, Date date) {
+    public GHCommitBuilder author(String name, String email, Instant date) {
         req.with("author", new UserInfo(name, email, date));
         return this;
     }
@@ -120,7 +114,7 @@ public class GHCommitBuilder {
      *            the date
      * @return the gh commit builder
      */
-    public GHCommitBuilder committer(String name, String email, Date date) {
+    public GHCommitBuilder committer(String name, String email, Instant date) {
         req.with("committer", new UserInfo(name, email, date));
         return this;
     }

--- a/src/main/java/org/kohsuke/github/GHCommitQueryBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHCommitQueryBuilder.java
@@ -1,6 +1,6 @@
 package org.kohsuke.github;
 
-import java.util.Date;
+import java.time.Instant;
 
 // TODO: Auto-generated Javadoc
 /**
@@ -89,8 +89,8 @@ public class GHCommitQueryBuilder {
      *            the dt
      * @return the gh commit query builder
      */
-    public GHCommitQueryBuilder since(Date dt) {
-        req.with("since", GitHubClient.printDate(dt));
+    public GHCommitQueryBuilder since(Instant dt) {
+        req.with("since", GitHubClient.printInstant(dt));
         return this;
     }
 
@@ -102,7 +102,7 @@ public class GHCommitQueryBuilder {
      * @return the gh commit query builder
      */
     public GHCommitQueryBuilder since(long timestamp) {
-        return since(new Date(timestamp));
+        return since(Instant.ofEpochMilli(timestamp));
     }
 
     /**
@@ -112,8 +112,8 @@ public class GHCommitQueryBuilder {
      *            the dt
      * @return the gh commit query builder
      */
-    public GHCommitQueryBuilder until(Date dt) {
-        req.with("until", GitHubClient.printDate(dt));
+    public GHCommitQueryBuilder until(Instant dt) {
+        req.with("until", GitHubClient.printInstant(dt));
         return this;
     }
 
@@ -125,7 +125,7 @@ public class GHCommitQueryBuilder {
      * @return the gh commit query builder
      */
     public GHCommitQueryBuilder until(long timestamp) {
-        return until(new Date(timestamp));
+        return until(Instant.ofEpochMilli(timestamp));
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHDeployKey.java
+++ b/src/main/java/org/kohsuke/github/GHDeployKey.java
@@ -3,7 +3,7 @@ package org.kohsuke.github;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.io.IOException;
-import java.util.Date;
+import java.time.Instant;
 
 // TODO: Auto-generated Javadoc
 /**
@@ -89,8 +89,8 @@ public class GHDeployKey {
      *
      * @return the created_at
      */
-    public Date getCreatedAt() {
-        return GitHubClient.parseDate(created_at);
+    public Instant getCreatedAt() {
+        return GitHubClient.parseInstant(created_at);
     }
 
     /**
@@ -98,8 +98,8 @@ public class GHDeployKey {
      *
      * @return the last_used
      */
-    public Date getLastUsedAt() {
-        return GitHubClient.parseDate(last_used);
+    public Instant getLastUsedAt() {
+        return GitHubClient.parseInstant(last_used);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHEventInfo.java
+++ b/src/main/java/org/kohsuke/github/GHEventInfo.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.*;
 
 // TODO: Auto-generated Javadoc
@@ -128,8 +129,8 @@ public class GHEventInfo extends GitHubInteractiveObject {
      *
      * @return the created at
      */
-    public Date getCreatedAt() {
-        return GitHubClient.parseDate(created_at);
+    public Instant getCreatedAt() {
+        return GitHubClient.parseInstant(created_at);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHEventPayload.java
+++ b/src/main/java/org/kohsuke/github/GHEventPayload.java
@@ -6,9 +6,9 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -1363,8 +1363,8 @@ public abstract class GHEventPayload extends GitHubInteractiveObject {
              *
              * @return the timestamp
              */
-            public Date getTimestamp() {
-                return GitHubClient.parseDate(timestamp);
+            public Instant getTimestamp() {
+                return GitHubClient.parseInstant(timestamp);
             }
         }
     }
@@ -1809,8 +1809,8 @@ public abstract class GHEventPayload extends GitHubInteractiveObject {
          *
          * @return the date when the star is added
          */
-        public Date getStarredAt() {
-            return GitHubClient.parseDate(starredAt);
+        public Instant getStarredAt() {
+            return GitHubClient.parseInstant(starredAt);
         }
     }
 

--- a/src/main/java/org/kohsuke/github/GHExternalGroup.java
+++ b/src/main/java/org/kohsuke/github/GHExternalGroup.java
@@ -3,8 +3,8 @@ package org.kohsuke.github;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 
 /**
@@ -223,8 +223,8 @@ public class GHExternalGroup extends GitHubInteractiveObject implements Refresha
      *
      * @return the date
      */
-    public Date getUpdatedAt() {
-        return GitHubClient.parseDate(updatedAt);
+    public Instant getUpdatedAt() {
+        return GitHubClient.parseInstant(updatedAt);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHIssue.java
+++ b/src/main/java/org/kohsuke/github/GHIssue.java
@@ -30,11 +30,11 @@ import org.kohsuke.github.internal.EnumUtils;
 
 import java.io.IOException;
 import java.net.URL;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -234,8 +234,8 @@ public class GHIssue extends GHObject implements Reactable {
      *
      * @return the closed at
      */
-    public Date getClosedAt() {
-        return GitHubClient.parseDate(closed_at);
+    public Instant getClosedAt() {
+        return GitHubClient.parseInstant(closed_at);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHIssueCommentQueryBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHIssueCommentQueryBuilder.java
@@ -1,6 +1,6 @@
 package org.kohsuke.github;
 
-import java.util.Date;
+import java.time.Instant;
 
 // TODO: Auto-generated Javadoc
 /**
@@ -41,8 +41,8 @@ public class GHIssueCommentQueryBuilder {
      *            the date
      * @return the query builder
      */
-    public GHIssueCommentQueryBuilder since(Date date) {
-        req.with("since", GitHubClient.printDate(date));
+    public GHIssueCommentQueryBuilder since(Instant date) {
+        req.with("since", GitHubClient.printInstant(date));
         return this;
     }
 
@@ -54,7 +54,7 @@ public class GHIssueCommentQueryBuilder {
      * @return the query builder
      */
     public GHIssueCommentQueryBuilder since(long timestamp) {
-        return since(new Date(timestamp));
+        return since(Instant.ofEpochMilli(timestamp));
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHIssueEvent.java
+++ b/src/main/java/org/kohsuke/github/GHIssueEvent.java
@@ -2,7 +2,7 @@ package org.kohsuke.github;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
-import java.util.Date;
+import java.time.Instant;
 
 // TODO: Auto-generated Javadoc
 /**
@@ -105,8 +105,8 @@ public class GHIssueEvent extends GitHubInteractiveObject {
      *
      * @return the created at
      */
-    public Date getCreatedAt() {
-        return GitHubClient.parseDate(created_at);
+    public Instant getCreatedAt() {
+        return GitHubClient.parseInstant(created_at);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHIssueQueryBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHIssueQueryBuilder.java
@@ -1,7 +1,7 @@
 package org.kohsuke.github;
 
+import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 // TODO: Auto-generated Javadoc
@@ -79,8 +79,8 @@ public abstract class GHIssueQueryBuilder extends GHQueryBuilder<GHIssue> {
      *            the date
      * @return the gh issue query builder
      */
-    public GHIssueQueryBuilder since(Date date) {
-        req.with("since", GitHubClient.printDate(date));
+    public GHIssueQueryBuilder since(Instant date) {
+        req.with("since", GitHubClient.printInstant(date));
         return this;
     }
 
@@ -92,7 +92,7 @@ public abstract class GHIssueQueryBuilder extends GHQueryBuilder<GHIssue> {
      * @return the gh issue query builder
      */
     public GHIssueQueryBuilder since(long timestamp) {
-        return since(new Date(timestamp));
+        return since(Instant.ofEpochMilli(timestamp));
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHMarketplacePendingChange.java
+++ b/src/main/java/org/kohsuke/github/GHMarketplacePendingChange.java
@@ -2,7 +2,7 @@ package org.kohsuke.github;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
-import java.util.Date;
+import java.time.Instant;
 
 // TODO: Auto-generated Javadoc
 /**
@@ -59,8 +59,8 @@ public class GHMarketplacePendingChange extends GitHubInteractiveObject {
      *
      * @return the effective date
      */
-    public Date getEffectiveDate() {
-        return GitHubClient.parseDate(effectiveDate);
+    public Instant getEffectiveDate() {
+        return GitHubClient.parseInstant(effectiveDate);
     }
 
 }

--- a/src/main/java/org/kohsuke/github/GHMarketplacePurchase.java
+++ b/src/main/java/org/kohsuke/github/GHMarketplacePurchase.java
@@ -2,7 +2,7 @@ package org.kohsuke.github;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
-import java.util.Date;
+import java.time.Instant;
 
 // TODO: Auto-generated Javadoc
 /**
@@ -42,8 +42,8 @@ public class GHMarketplacePurchase extends GitHubInteractiveObject {
      *
      * @return the next billing date
      */
-    public Date getNextBillingDate() {
-        return GitHubClient.parseDate(nextBillingDate);
+    public Instant getNextBillingDate() {
+        return GitHubClient.parseInstant(nextBillingDate);
     }
 
     /**
@@ -60,8 +60,8 @@ public class GHMarketplacePurchase extends GitHubInteractiveObject {
      *
      * @return the free trial ends on
      */
-    public Date getFreeTrialEndsOn() {
-        return GitHubClient.parseDate(freeTrialEndsOn);
+    public Instant getFreeTrialEndsOn() {
+        return GitHubClient.parseInstant(freeTrialEndsOn);
     }
 
     /**
@@ -78,8 +78,8 @@ public class GHMarketplacePurchase extends GitHubInteractiveObject {
      *
      * @return the updated at
      */
-    public Date getUpdatedAt() {
-        return GitHubClient.parseDate(updatedAt);
+    public Instant getUpdatedAt() {
+        return GitHubClient.parseInstant(updatedAt);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHMarketplaceUserPurchase.java
+++ b/src/main/java/org/kohsuke/github/GHMarketplaceUserPurchase.java
@@ -2,7 +2,7 @@ package org.kohsuke.github;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
-import java.util.Date;
+import java.time.Instant;
 
 // TODO: Auto-generated Javadoc
 /**
@@ -44,8 +44,8 @@ public class GHMarketplaceUserPurchase extends GitHubInteractiveObject {
      *
      * @return the next billing date
      */
-    public Date getNextBillingDate() {
-        return GitHubClient.parseDate(nextBillingDate);
+    public Instant getNextBillingDate() {
+        return GitHubClient.parseInstant(nextBillingDate);
     }
 
     /**
@@ -62,8 +62,8 @@ public class GHMarketplaceUserPurchase extends GitHubInteractiveObject {
      *
      * @return the free trial ends on
      */
-    public Date getFreeTrialEndsOn() {
-        return GitHubClient.parseDate(freeTrialEndsOn);
+    public Instant getFreeTrialEndsOn() {
+        return GitHubClient.parseInstant(freeTrialEndsOn);
     }
 
     /**
@@ -80,8 +80,8 @@ public class GHMarketplaceUserPurchase extends GitHubInteractiveObject {
      *
      * @return the updated at
      */
-    public Date getUpdatedAt() {
-        return GitHubClient.parseDate(updatedAt);
+    public Instant getUpdatedAt() {
+        return GitHubClient.parseInstant(updatedAt);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHMilestone.java
+++ b/src/main/java/org/kohsuke/github/GHMilestone.java
@@ -4,7 +4,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
 import java.net.URL;
-import java.util.Date;
+import java.time.Instant;
 import java.util.Locale;
 
 // TODO: Auto-generated Javadoc
@@ -56,10 +56,10 @@ public class GHMilestone extends GHObject {
      *
      * @return the due on
      */
-    public Date getDueOn() {
+    public Instant getDueOn() {
         if (due_on == null)
             return null;
-        return GitHubClient.parseDate(due_on);
+        return GitHubClient.parseInstant(due_on);
     }
 
     /**
@@ -67,8 +67,8 @@ public class GHMilestone extends GHObject {
      *
      * @return the closed at
      */
-    public Date getClosedAt() {
-        return GitHubClient.parseDate(closed_at);
+    public Instant getClosedAt() {
+        return GitHubClient.parseInstant(closed_at);
     }
 
     /**
@@ -200,8 +200,8 @@ public class GHMilestone extends GHObject {
      * @throws IOException
      *             the io exception
      */
-    public void setDueOn(Date dueOn) throws IOException {
-        edit("due_on", GitHubClient.printDate(dueOn));
+    public void setDueOn(Instant dueOn) throws IOException {
+        edit("due_on", GitHubClient.printInstant(dueOn));
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHNotificationStream.java
+++ b/src/main/java/org/kohsuke/github/GHNotificationStream.java
@@ -1,7 +1,7 @@
 package org.kohsuke.github;
 
 import java.io.IOException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
@@ -75,7 +75,7 @@ public class GHNotificationStream extends GitHubInteractiveObject implements Ite
      * @return the gh notification stream
      */
     public GHNotificationStream since(long timestamp) {
-        return since(new Date(timestamp));
+        return since(Instant.ofEpochMilli(timestamp));
     }
 
     /**
@@ -85,8 +85,8 @@ public class GHNotificationStream extends GitHubInteractiveObject implements Ite
      *            the dt
      * @return the gh notification stream
      */
-    public GHNotificationStream since(Date dt) {
-        since = GitHubClient.printDate(dt);
+    public GHNotificationStream since(Instant dt) {
+        since = GitHubClient.printInstant(dt);
         return this;
     }
 
@@ -168,7 +168,7 @@ public class GHNotificationStream extends GitHubInteractiveObject implements Ite
                         // if we have fetched un-returned threads, use them first
                         while (idx >= 0) {
                             GHThread n = threads[idx--];
-                            long nt = n.getUpdatedAt().getTime();
+                            long nt = n.getUpdatedAt().toEpochMilli();
                             if (nt >= lastUpdated) {
                                 lastUpdated = nt;
                                 return n;
@@ -243,7 +243,7 @@ public class GHNotificationStream extends GitHubInteractiveObject implements Ite
     public void markAsRead(long timestamp) throws IOException {
         final Requester req = root().createRequest();
         if (timestamp >= 0)
-            req.with("last_read_at", GitHubClient.printDate(new Date(timestamp)));
+            req.with("last_read_at", GitHubClient.printInstant(Instant.ofEpochMilli(timestamp)));
         req.withUrlPath(apiUrl).fetchHttpStatusCode();
     }
 

--- a/src/main/java/org/kohsuke/github/GHObject.java
+++ b/src/main/java/org/kohsuke/github/GHObject.java
@@ -6,14 +6,13 @@ import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 import org.kohsuke.github.connector.GitHubConnectorResponse;
 
+import javax.annotation.CheckForNull;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.URL;
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
-
-import javax.annotation.CheckForNull;
 
 // TODO: Auto-generated Javadoc
 /**
@@ -78,8 +77,8 @@ public abstract class GHObject extends GitHubInteractiveObject {
      * @throws IOException
      *             on error
      */
-    public Date getCreatedAt() throws IOException {
-        return GitHubClient.parseDate(createdAt);
+    public Instant getCreatedAt() throws IOException {
+        return GitHubClient.parseInstant(createdAt);
     }
 
     /**
@@ -98,8 +97,8 @@ public abstract class GHObject extends GitHubInteractiveObject {
      * @throws IOException
      *             on error
      */
-    public Date getUpdatedAt() throws IOException {
-        return GitHubClient.parseDate(updatedAt);
+    public Instant getUpdatedAt() throws IOException {
+        return GitHubClient.parseInstant(updatedAt);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHPerson.java
+++ b/src/main/java/org/kohsuke/github/GHPerson.java
@@ -3,8 +3,8 @@ package org.kohsuke.github;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URL;
+import java.time.Instant;
 import java.util.Collections;
-import java.util.Date;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
@@ -208,7 +208,7 @@ public abstract class GHPerson extends GHObject {
      * @throws IOException
      *             Signals that an I/O exception has occurred.
      */
-    public Date getCreatedAt() throws IOException {
+    public Instant getCreatedAt() throws IOException {
         populate();
         return super.getCreatedAt();
     }
@@ -220,7 +220,7 @@ public abstract class GHPerson extends GHObject {
      * @throws IOException
      *             Signals that an I/O exception has occurred.
      */
-    public Date getUpdatedAt() throws IOException {
+    public Instant getUpdatedAt() throws IOException {
         populate();
         return super.getUpdatedAt();
     }

--- a/src/main/java/org/kohsuke/github/GHProjectsV2Item.java
+++ b/src/main/java/org/kohsuke/github/GHProjectsV2Item.java
@@ -3,7 +3,7 @@ package org.kohsuke.github;
 import org.kohsuke.github.internal.EnumUtils;
 
 import java.net.URL;
-import java.util.Date;
+import java.time.Instant;
 
 // TODO: Auto-generated Javadoc
 /**
@@ -76,8 +76,8 @@ public class GHProjectsV2Item extends GHObject {
      *
      * @return the archived at
      */
-    public Date getArchivedAt() {
-        return GitHubClient.parseDate(archivedAt);
+    public Instant getArchivedAt() {
+        return GitHubClient.parseInstant(archivedAt);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHProjectsV2ItemChanges.java
+++ b/src/main/java/org/kohsuke/github/GHProjectsV2ItemChanges.java
@@ -3,7 +3,7 @@ package org.kohsuke.github;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.kohsuke.github.internal.EnumUtils;
 
-import java.util.Date;
+import java.time.Instant;
 
 // TODO: Auto-generated Javadoc
 /**
@@ -138,8 +138,8 @@ public class GHProjectsV2ItemChanges {
          *
          * @return the from
          */
-        public Date getFrom() {
-            return GitHubClient.parseDate(from);
+        public Instant getFrom() {
+            return GitHubClient.parseInstant(from);
         }
 
         /**
@@ -147,8 +147,8 @@ public class GHProjectsV2ItemChanges {
          *
          * @return the to
          */
-        public Date getTo() {
-            return GitHubClient.parseDate(to);
+        public Instant getTo() {
+            return GitHubClient.parseInstant(to);
         }
     }
 

--- a/src/main/java/org/kohsuke/github/GHPullRequest.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequest.java
@@ -28,10 +28,10 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 import java.net.URL;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 
@@ -170,8 +170,8 @@ public class GHPullRequest extends GHIssue implements Refreshable {
      *
      * @return the merged at
      */
-    public Date getMergedAt() {
-        return GitHubClient.parseDate(merged_at);
+    public Instant getMergedAt() {
+        return GitHubClient.parseInstant(merged_at);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHPullRequestReview.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequestReview.java
@@ -25,11 +25,10 @@ package org.kohsuke.github;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import javax.annotation.CheckForNull;
 import java.io.IOException;
 import java.net.URL;
-import java.util.Date;
-
-import javax.annotation.CheckForNull;
+import java.time.Instant;
 
 // TODO: Auto-generated Javadoc
 /**
@@ -144,8 +143,8 @@ public class GHPullRequestReview extends GHObject {
      *
      * @return the submitted at
      */
-    public Date getSubmittedAt() {
-        return GitHubClient.parseDate(submitted_at);
+    public Instant getSubmittedAt() {
+        return GitHubClient.parseInstant(submitted_at);
     }
 
     /**
@@ -156,7 +155,7 @@ public class GHPullRequestReview extends GHObject {
      *             Signals that an I/O exception has occurred.
      */
     @Override
-    public Date getCreatedAt() throws IOException {
+    public Instant getCreatedAt() throws IOException {
         return getSubmittedAt();
     }
 

--- a/src/main/java/org/kohsuke/github/GHRateLimit.java
+++ b/src/main/java/org/kohsuke/github/GHRateLimit.java
@@ -8,10 +8,10 @@ import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.github.connector.GitHubConnectorResponse;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
-import java.util.Date;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Logger;
@@ -131,7 +131,7 @@ public class GHRateLimit {
      * @return the calculated date at which the rate limit has or will reset.
      */
     @Nonnull
-    public Date getResetDate() {
+    public Instant getResetDate() {
         return getCore().getResetDate();
     }
 
@@ -416,7 +416,7 @@ public class GHRateLimit {
          * @see #getResetDate()
          */
         @Nonnull
-        private final Date resetDate;
+        private final Instant resetDate;
 
         /**
          * Instantiates a new Record.
@@ -535,7 +535,7 @@ public class GHRateLimit {
          * @return reset date based on the passed date
          */
         @Nonnull
-        private Date calculateResetDate(@CheckForNull String updatedAt) {
+        private Instant calculateResetDate(@CheckForNull String updatedAt) {
             long updatedAtEpochSeconds = createdAtEpochSeconds;
             if (!StringUtils.isBlank(updatedAt)) {
                 try {
@@ -552,7 +552,7 @@ public class GHRateLimit {
             // This may seem odd but it results in an accurate or slightly pessimistic reset date
             // based on system time rather than assuming the system time synchronized with the server
             long calculatedSecondsUntilReset = resetEpochSeconds - updatedAtEpochSeconds;
-            return new Date((createdAtEpochSeconds + calculatedSecondsUntilReset) * 1000);
+            return Instant.ofEpochMilli((createdAtEpochSeconds + calculatedSecondsUntilReset) * 1000);
         }
 
         /**
@@ -595,7 +595,7 @@ public class GHRateLimit {
          * @return true if the rate limit reset date has passed. Otherwise false.
          */
         public boolean isExpired() {
-            return getResetDate().getTime() < System.currentTimeMillis();
+            return getResetDate().toEpochMilli() < System.currentTimeMillis();
         }
 
         /**
@@ -607,8 +607,8 @@ public class GHRateLimit {
          * @return the calculated date at which the rate limit has or will reset.
          */
         @Nonnull
-        public Date getResetDate() {
-            return new Date(resetDate.getTime());
+        public Instant getResetDate() {
+            return resetDate;
         }
 
         /**

--- a/src/main/java/org/kohsuke/github/GHRelease.java
+++ b/src/main/java/org/kohsuke/github/GHRelease.java
@@ -8,11 +8,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.time.Instant;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 
-import static java.lang.String.*;
+import static java.lang.String.format;
 
 // TODO: Auto-generated Javadoc
 /**
@@ -42,7 +42,7 @@ public class GHRelease extends GHObject {
     private String body;
     private boolean draft;
     private boolean prerelease;
-    private Date published_at;
+    private Instant published_at;
     private String tarball_url;
     private String zipball_url;
     private String discussion_url;
@@ -135,8 +135,8 @@ public class GHRelease extends GHObject {
      *
      * @return the published at
      */
-    public Date getPublished_at() {
-        return new Date(published_at.getTime());
+    public Instant getPublished_at() {
+        return published_at;
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -37,10 +37,10 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.net.URL;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -815,8 +815,8 @@ public class GHRepository extends GHObject {
      *
      * @return null if the repository was never pushed at.
      */
-    public Date getPushedAt() {
-        return GitHubClient.parseDate(pushed_at);
+    public Instant getPushedAt() {
+        return GitHubClient.parseInstant(pushed_at);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHRepositoryDiscussion.java
+++ b/src/main/java/org/kohsuke/github/GHRepositoryDiscussion.java
@@ -3,7 +3,7 @@ package org.kohsuke.github;
 import org.kohsuke.github.internal.EnumUtils;
 
 import java.net.URL;
-import java.util.Date;
+import java.time.Instant;
 
 // TODO: Auto-generated Javadoc
 /**
@@ -69,8 +69,8 @@ public class GHRepositoryDiscussion extends GHObject {
      *
      * @return the answer chosen at
      */
-    public Date getAnswerChosenAt() {
-        return GitHubClient.parseDate(answerChosenAt);
+    public Instant getAnswerChosenAt() {
+        return GitHubClient.parseInstant(answerChosenAt);
     }
 
     /**
@@ -269,8 +269,8 @@ public class GHRepositoryDiscussion extends GHObject {
          *
          * @return the created at
          */
-        public Date getCreatedAt() {
-            return GitHubClient.parseDate(createdAt);
+        public Instant getCreatedAt() {
+            return GitHubClient.parseInstant(createdAt);
         }
 
         /**
@@ -278,8 +278,8 @@ public class GHRepositoryDiscussion extends GHObject {
          *
          * @return the updated at
          */
-        public Date getUpdatedAt() {
-            return GitHubClient.parseDate(updatedAt);
+        public Instant getUpdatedAt() {
+            return GitHubClient.parseInstant(updatedAt);
         }
 
         /**

--- a/src/main/java/org/kohsuke/github/GHRepositoryTraffic.java
+++ b/src/main/java/org/kohsuke/github/GHRepositoryTraffic.java
@@ -1,6 +1,6 @@
 package org.kohsuke.github;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 
 // TODO: Auto-generated Javadoc
@@ -68,8 +68,8 @@ public abstract class GHRepositoryTraffic implements TrafficInfo {
          *
          * @return the timestamp
          */
-        public Date getTimestamp() {
-            return GitHubClient.parseDate(timestamp);
+        public Instant getTimestamp() {
+            return GitHubClient.parseInstant(timestamp);
         }
 
         /**

--- a/src/main/java/org/kohsuke/github/GHStargazer.java
+++ b/src/main/java/org/kohsuke/github/GHStargazer.java
@@ -2,7 +2,7 @@ package org.kohsuke.github;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
-import java.util.Date;
+import java.time.Instant;
 
 // TODO: Auto-generated Javadoc
 /**
@@ -39,8 +39,8 @@ public class GHStargazer {
      *
      * @return the date the stargazer was added
      */
-    public Date getStarredAt() {
-        return GitHubClient.parseDate(starred_at);
+    public Instant getStarredAt() {
+        return GitHubClient.parseInstant(starred_at);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHSubscription.java
+++ b/src/main/java/org/kohsuke/github/GHSubscription.java
@@ -3,7 +3,7 @@ package org.kohsuke.github;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
-import java.util.Date;
+import java.time.Instant;
 
 // TODO: Auto-generated Javadoc
 /**
@@ -31,8 +31,8 @@ public class GHSubscription extends GitHubInteractiveObject {
      *
      * @return the created at
      */
-    public Date getCreatedAt() {
-        return GitHubClient.parseDate(created_at);
+    public Instant getCreatedAt() {
+        return GitHubClient.parseInstant(created_at);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHThread.java
+++ b/src/main/java/org/kohsuke/github/GHThread.java
@@ -4,7 +4,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.util.Date;
+import java.time.Instant;
 
 // TODO: Auto-generated Javadoc
 /**
@@ -50,8 +50,8 @@ public class GHThread extends GHObject {
      *
      * @return the last read at
      */
-    public Date getLastReadAt() {
-        return GitHubClient.parseDate(last_read_at);
+    public Instant getLastReadAt() {
+        return GitHubClient.parseInstant(last_read_at);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHUser.java
+++ b/src/main/java/org/kohsuke/github/GHUser.java
@@ -24,6 +24,7 @@
 package org.kohsuke.github;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.*;
 
 // TODO: Auto-generated Javadoc
@@ -273,9 +274,9 @@ public class GHUser extends GHPerson {
      * @throws IOException
      *             on error
      */
-    public Date getSuspendedAt() throws IOException {
+    public Instant getSuspendedAt() throws IOException {
         super.populate();
-        return GitHubClient.parseDate(suspendedAt);
+        return GitHubClient.parseInstant(suspendedAt);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHWorkflowJob.java
+++ b/src/main/java/org/kohsuke/github/GHWorkflowJob.java
@@ -9,9 +9,9 @@ import org.kohsuke.github.function.InputStreamFunction;
 
 import java.io.IOException;
 import java.net.URL;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 
@@ -83,8 +83,8 @@ public class GHWorkflowJob extends GHObject {
      *
      * @return start date
      */
-    public Date getStartedAt() {
-        return GitHubClient.parseDate(startedAt);
+    public Instant getStartedAt() {
+        return GitHubClient.parseInstant(startedAt);
     }
 
     /**
@@ -92,8 +92,8 @@ public class GHWorkflowJob extends GHObject {
      *
      * @return completion date
      */
-    public Date getCompletedAt() {
-        return GitHubClient.parseDate(completedAt);
+    public Instant getCompletedAt() {
+        return GitHubClient.parseInstant(completedAt);
     }
 
     /**
@@ -302,8 +302,8 @@ public class GHWorkflowJob extends GHObject {
          *
          * @return start date
          */
-        public Date getStartedAt() {
-            return GitHubClient.parseDate(startedAt);
+        public Instant getStartedAt() {
+            return GitHubClient.parseInstant(startedAt);
         }
 
         /**
@@ -311,8 +311,8 @@ public class GHWorkflowJob extends GHObject {
          *
          * @return completion date
          */
-        public Date getCompletedAt() {
-            return GitHubClient.parseDate(completedAt);
+        public Instant getCompletedAt() {
+            return GitHubClient.parseInstant(completedAt);
         }
 
         /**

--- a/src/main/java/org/kohsuke/github/GHWorkflowRun.java
+++ b/src/main/java/org/kohsuke/github/GHWorkflowRun.java
@@ -8,9 +8,9 @@ import org.kohsuke.github.internal.EnumUtils;
 
 import java.io.IOException;
 import java.net.URL;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -114,8 +114,8 @@ public class GHWorkflowRun extends GHObject {
      *
      * @return run triggered
      */
-    public Date getRunStartedAt() {
-        return GitHubClient.parseDate(runStartedAt);
+    public Instant getRunStartedAt() {
+        return GitHubClient.parseInstant(runStartedAt);
     }
 
     /**
@@ -487,8 +487,8 @@ public class GHWorkflowRun extends GHObject {
          *
          * @return timestamp of the commit
          */
-        public Date getTimestamp() {
-            return GitHubClient.parseDate(timestamp);
+        public Instant getTimestamp() {
+            return GitHubClient.parseInstant(timestamp);
         }
 
         /**

--- a/src/main/java/org/kohsuke/github/GitCommit.java
+++ b/src/main/java/org/kohsuke/github/GitCommit.java
@@ -2,9 +2,9 @@ package org.kohsuke.github;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import java.time.Instant;
 import java.util.AbstractList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 
 // TODO: Auto-generated Javadoc
@@ -159,7 +159,7 @@ public class GitCommit {
      *
      * @return the authored date
      */
-    public Date getAuthoredDate() {
+    public Instant getAuthoredDate() {
         return author.getDate();
     }
 
@@ -177,7 +177,7 @@ public class GitCommit {
      *
      * @return the commit date
      */
-    public Date getCommitDate() {
+    public Instant getCommitDate() {
         return committer.getDate();
     }
 

--- a/src/main/java/org/kohsuke/github/GitHubClient.java
+++ b/src/main/java/org/kohsuke/github/GitHubClient.java
@@ -2,6 +2,7 @@ package org.kohsuke.github;
 
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.introspect.VisibilityChecker;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.apache.commons.io.IOUtils;
 import org.kohsuke.github.authorization.AuthorizationProvider;
 import org.kohsuke.github.authorization.UserAuthorizationProvider;
@@ -90,6 +91,7 @@ class GitHubClient {
             .ofPattern("yyyy/MM/dd HH:mm:ss Z");
 
     static {
+        MAPPER.registerModule(new JavaTimeModule());
         MAPPER.setVisibility(new VisibilityChecker.Std(NONE, NONE, NONE, NONE, ANY));
         MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         MAPPER.configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS, true);
@@ -874,20 +876,6 @@ class GitHubClient {
     }
 
     /**
-     * Parses the date.
-     *
-     * @param timestamp
-     *            the timestamp
-     * @return the date
-     */
-    static Date parseDate(String timestamp) {
-        if (timestamp == null)
-            return null;
-
-        return Date.from(parseInstant(timestamp));
-    }
-
-    /**
      * Parses the instant.
      *
      * @param timestamp
@@ -907,14 +895,14 @@ class GitHubClient {
     }
 
     /**
-     * Prints the date.
+     * Prints the instant.
      *
-     * @param dt
-     *            the dt
+     * @param instant
+     *            the instant
      * @return the string
      */
-    static String printDate(Date dt) {
-        return DateTimeFormatter.ISO_INSTANT.format(Instant.ofEpochMilli(dt.getTime()).truncatedTo(ChronoUnit.SECONDS));
+    static String printInstant(Instant instant) {
+        return DateTimeFormatter.ISO_INSTANT.format(instant.truncatedTo(ChronoUnit.SECONDS));
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GitUser.java
+++ b/src/main/java/org/kohsuke/github/GitUser.java
@@ -2,7 +2,7 @@ package org.kohsuke.github;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
-import java.util.Date;
+import java.time.Instant;
 
 import javax.annotation.CheckForNull;
 
@@ -53,8 +53,8 @@ public class GitUser {
      *
      * @return Commit Date.
      */
-    public Date getDate() {
-        return GitHubClient.parseDate(date);
+    public Instant getDate() {
+        return GitHubClient.parseInstant(date);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/RateLimitChecker.java
+++ b/src/main/java/org/kohsuke/github/RateLimitChecker.java
@@ -79,7 +79,7 @@ public abstract class RateLimitChecker {
      */
     protected final boolean sleepUntilReset(GHRateLimit.Record record) throws InterruptedException {
         // Sleep until reset
-        long sleepMilliseconds = record.getResetDate().getTime() - System.currentTimeMillis();
+        long sleepMilliseconds = record.getResetDate().toEpochMilli() - System.currentTimeMillis();
         if (sleepMilliseconds > 0) {
             String message = String.format(
                     "GitHub API - Current quota has %d remaining of %d. Waiting for quota to reset at %tT.",

--- a/src/main/java/org/kohsuke/github/authorization/AppInstallationAuthorizationProvider.java
+++ b/src/main/java/org/kohsuke/github/authorization/AppInstallationAuthorizationProvider.java
@@ -7,8 +7,8 @@ import org.kohsuke.github.GHAppInstallationToken;
 import org.kohsuke.github.GitHub;
 
 import java.io.IOException;
-import java.time.Duration;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Objects;
 
 import javax.annotation.Nonnull;
@@ -57,7 +57,7 @@ public class AppInstallationAuthorizationProvider extends GitHub.DependentAuthor
         GitHub gitHub = this.gitHub();
         GHAppInstallation installationByOrganization = appInstallationProvider.getAppInstallation(gitHub.getApp());
         GHAppInstallationToken ghAppInstallationToken = installationByOrganization.createToken().create();
-        this.validUntil = ghAppInstallationToken.getExpiresAt().toInstant().minus(Duration.ofMinutes(5));
+        this.validUntil = ghAppInstallationToken.getExpiresAt().minus(5, ChronoUnit.MINUTES);
         return Objects.requireNonNull(ghAppInstallationToken.getToken());
     }
 

--- a/src/main/java/org/kohsuke/github/extras/authorization/JwtBuilderUtil.java
+++ b/src/main/java/org/kohsuke/github/extras/authorization/JwtBuilderUtil.java
@@ -123,6 +123,8 @@ final class JwtBuilderUtil {
             SignatureAlgorithm rs256 = Jwts.SIG.RS256;
 
             JwtBuilder jwtBuilder = Jwts.builder();
+            // jjwt uses the legacy java date-time api
+            // see https://github.com/jwtk/jjwt/issues/235 for future support for java 8 date-time api
             jwtBuilder = jwtBuilder.issuedAt(Date.from(issuedAt))
                     .expiration(Date.from(expiration))
                     .issuer(applicationId)
@@ -148,8 +150,12 @@ final class JwtBuilderUtil {
             JwtBuilder jwtBuilder = Jwts.builder();
             Class<?> jwtReflectionClass = jwtBuilder.getClass();
 
+            // jjwt uses the legacy java date-time api
+            // see https://github.com/jwtk/jjwt/issues/235 for future support for java 8 date-time api
+            // noinspection UseOfObsoleteDateTimeApi
             setIssuedAtMethod = jwtReflectionClass.getMethod("setIssuedAt", Date.class);
             setIssuerMethod = jwtReflectionClass.getMethod("setIssuer", String.class);
+            // noinspection UseOfObsoleteDateTimeApi
             setExpirationMethod = jwtReflectionClass.getMethod("setExpiration", Date.class);
             Class<?> signatureAlgorithmClass = Class.forName("io.jsonwebtoken.SignatureAlgorithm");
             rs256SignatureAlgorithm = createEnumInstance(signatureAlgorithmClass, "RS256");
@@ -186,6 +192,8 @@ final class JwtBuilderUtil {
                 PrivateKey privateKey) throws IllegalAccessException, InvocationTargetException {
             JwtBuilder jwtBuilder = Jwts.builder();
             Object builderObj = jwtBuilder;
+            // jjwt uses the legacy java date-time api
+            // see https://github.com/jwtk/jjwt/issues/235 for future support for java 8 date-time api
             builderObj = setIssuedAtMethod.invoke(builderObj, Date.from(issuedAt));
             builderObj = setExpirationMethod.invoke(builderObj, Date.from(expiration));
             builderObj = setIssuerMethod.invoke(builderObj, applicationId);

--- a/src/test/java/org/kohsuke/github/AbstractGitHubWireMockTest.java
+++ b/src/test/java/org/kohsuke/github/AbstractGitHubWireMockTest.java
@@ -395,6 +395,7 @@ public abstract class AbstractGitHubWireMockTest {
     protected static class TemplatingHelper {
 
         /** The test start date. */
+        @SuppressWarnings("UseOfObsoleteDateTimeApi")
         public Date testStartDate = new Date();
 
         /**
@@ -409,11 +410,12 @@ public abstract class AbstractGitHubWireMockTest {
          * @return the response template transformer
          */
         public ResponseTemplateTransformer newResponseTransformer() {
+            //noinspection UnqualifiedFieldAccess
             testStartDate = new Date();
             return ResponseTemplateTransformer.builder()
                     .global(true)
                     .maxCacheEntries(0L)
-                    .helper("testStartDate", new Helper<Object>() {
+                    .helper("testStartDate", new Helper<>() {
                         private HandlebarsCurrentDateHelper helper = new HandlebarsCurrentDateHelper();
                         @Override
                         public Object apply(final Object context, final Options options) throws IOException {

--- a/src/test/java/org/kohsuke/github/AppTest.java
+++ b/src/test/java/org/kohsuke/github/AppTest.java
@@ -798,8 +798,8 @@ public class AppTest extends AbstractGitHubWireMockTest {
         assertThat(commit.getLinesChanged(), equalTo(48));
         assertThat(commit.getLinesDeleted(), equalTo(8));
         assertThat(commit.getParentSHA1s().size(), equalTo(1));
-        assertThat(commit.getAuthoredDate(), equalTo(GitHubClient.parseDate("2012-04-24T00:16:52Z")));
-        assertThat(commit.getCommitDate(), equalTo(GitHubClient.parseDate("2012-04-24T00:16:52Z")));
+        assertThat(commit.getAuthoredDate(), equalTo(GitHubClient.parseInstant("2012-04-24T00:16:52Z")));
+        assertThat(commit.getCommitDate(), equalTo(GitHubClient.parseInstant("2012-04-24T00:16:52Z")));
         assertThat(commit.getCommitShortInfo().getCommentCount(), equalTo(0));
         assertThat(commit.getCommitShortInfo().getAuthoredDate(), equalTo(commit.getAuthoredDate()));
         assertThat(commit.getCommitShortInfo().getCommitDate(), equalTo(commit.getCommitDate()));
@@ -1009,7 +1009,7 @@ public class AppTest extends AbstractGitHubWireMockTest {
                     assertThat(ev.getActorLogin(), equalTo("pull[bot]"));
                     assertThat(ev.getOrganization(), nullValue());
                     assertThat(ev.getRepository().getFullName(), equalTo("daddyfatstacksBIG/lerna"));
-                    assertThat(ev.getCreatedAt(), equalTo(GitHubClient.parseDate("2019-10-21T21:54:52Z")));
+                    assertThat(ev.getCreatedAt(), equalTo(GitHubClient.parseInstant("2019-10-21T21:54:52Z")));
                     assertThat(ev.getType(), equalTo(GHEvent.PULL_REQUEST));
                 }
 
@@ -1033,7 +1033,7 @@ public class AppTest extends AbstractGitHubWireMockTest {
                     assertThat(ev.getActorLogin(), equalTo("PierreBtz"));
                     assertThat(ev.getOrganization().getLogin(), equalTo("hub4j"));
                     assertThat(ev.getRepository().getFullName(), equalTo("hub4j/github-api"));
-                    assertThat(ev.getCreatedAt(), equalTo(GitHubClient.parseDate("2023-03-02T16:37:49Z")));
+                    assertThat(ev.getCreatedAt(), equalTo(GitHubClient.parseInstant("2023-03-02T16:37:49Z")));
                     assertThat(ev.getType(), equalTo(GHEvent.PULL_REQUEST));
                 }
 
@@ -1212,9 +1212,9 @@ public class AppTest extends AbstractGitHubWireMockTest {
         assertThat("doc", equalTo(commit.getCommitShortInfo().getMessage()));
         assertThat(commit.getCommitShortInfo().getVerification().isVerified(), is(false));
         assertThat(GHVerification.Reason.UNSIGNED, equalTo(commit.getCommitShortInfo().getVerification().getReason()));
-        assertThat(commit.getCommitShortInfo().getAuthor().getDate().toInstant().getEpochSecond(),
+        assertThat(commit.getCommitShortInfo().getAuthor().getDate().getEpochSecond(),
                 equalTo(1271650361L));
-        assertThat(commit.getCommitShortInfo().getCommitter().getDate().toInstant().getEpochSecond(),
+        assertThat(commit.getCommitShortInfo().getCommitter().getDate().getEpochSecond(),
                 equalTo(1271650361L));
     }
 

--- a/src/test/java/org/kohsuke/github/CommitTest.java
+++ b/src/test/java/org/kohsuke/github/CommitTest.java
@@ -4,9 +4,9 @@ import com.google.common.collect.Iterables;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 
 import static org.hamcrest.Matchers.*;
@@ -123,8 +123,8 @@ public class CommitTest extends AbstractGitHubWireMockTest {
         commits = gitHub.getUser("jenkinsci")
                 .getRepository("jenkins")
                 .queryCommits()
-                .since(new Date(1199174400000L))
-                .until(new Date(1201852800000L))
+                .since(Instant.ofEpochMilli(1199174400000L))
+                .until(Instant.ofEpochMilli(1201852800000L))
                 .path("pom.xml")
                 .pageSize(100)
                 .list()
@@ -137,8 +137,8 @@ public class CommitTest extends AbstractGitHubWireMockTest {
         commits = gitHub.getUser("jenkinsci")
                 .getRepository("jenkins")
                 .queryCommits()
-                .since(new Date(1199174400000L))
-                .until(new Date(1201852800000L))
+                .since(Instant.ofEpochMilli(1199174400000L))
+                .until(Instant.ofEpochMilli(1201852800000L))
                 .path("pom.xml")
                 .from("a5259970acaec9813e2a12a91f37dfc7871a5ef5")
                 .list()
@@ -150,7 +150,7 @@ public class CommitTest extends AbstractGitHubWireMockTest {
         commits = gitHub.getUser("jenkinsci")
                 .getRepository("jenkins")
                 .queryCommits()
-                .until(new Date(1201852800000L))
+                .until(Instant.ofEpochMilli(1201852800000L))
                 .path("pom.xml")
                 .author("kohsuke")
                 .list()
@@ -161,7 +161,7 @@ public class CommitTest extends AbstractGitHubWireMockTest {
         commits = gitHub.getUser("jenkinsci")
                 .getRepository("jenkins")
                 .queryCommits()
-                .until(new Date(1201852800000L))
+                .until(Instant.ofEpochMilli(1201852800000L))
                 .path("pom.xml")
                 .pageSize(100)
                 .author("kohsuke@71c3de6d-444a-0410-be80-ed276b4c234a")
@@ -330,10 +330,10 @@ public class CommitTest extends AbstractGitHubWireMockTest {
         GHRepository repo = gitHub.getRepository("hub4j/github-api");
         GHCommit commit = repo.getCommit("865a49d2e86c24c5777985f0f103e975c4b765b9");
 
-        assertThat(commit.getCommitShortInfo().getAuthoredDate().toInstant().getEpochSecond(), equalTo(1609207093L));
+        assertThat(commit.getCommitShortInfo().getAuthoredDate().getEpochSecond(), equalTo(1609207093L));
         assertThat(commit.getCommitShortInfo().getAuthoredDate(),
                 equalTo(commit.getCommitShortInfo().getAuthor().getDate()));
-        assertThat(commit.getCommitShortInfo().getCommitDate().toInstant().getEpochSecond(), equalTo(1609207652L));
+        assertThat(commit.getCommitShortInfo().getCommitDate().getEpochSecond(), equalTo(1609207652L));
         assertThat(commit.getCommitShortInfo().getCommitDate(),
                 equalTo(commit.getCommitShortInfo().getCommitter().getDate()));
     }

--- a/src/test/java/org/kohsuke/github/GHAppInstallationTest.java
+++ b/src/test/java/org/kohsuke/github/GHAppInstallationTest.java
@@ -3,10 +3,10 @@ package org.kohsuke.github;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.Month;
 import java.time.ZoneOffset;
-import java.util.Date;
 import java.util.List;
 
 import static org.hamcrest.Matchers.*;
@@ -85,9 +85,8 @@ public class GHAppInstallationTest extends AbstractGHAppInstallationTest {
         final GHUser suspendedBy = appInstallation.getSuspendedBy();
         assertThat(suspendedBy.getLogin(), equalTo("gilday"));
 
-        final Date suspendedAt = appInstallation.getSuspendedAt();
-        final Date expectedSuspendedAt = Date
-                .from(LocalDateTime.of(2024, Month.FEBRUARY, 26, 2, 43, 12).toInstant(ZoneOffset.UTC));
+        final Instant suspendedAt = appInstallation.getSuspendedAt();
+        final Instant expectedSuspendedAt = LocalDateTime.of(2024, Month.FEBRUARY, 26, 2, 43, 12).toInstant(ZoneOffset.UTC);
         assertThat(suspendedAt, equalTo(expectedSuspendedAt));
     }
 

--- a/src/test/java/org/kohsuke/github/GHAppTest.java
+++ b/src/test/java/org/kohsuke/github/GHAppTest.java
@@ -3,15 +3,15 @@ package org.kohsuke.github;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.TimeZone;
 
 import static org.hamcrest.Matchers.*;
 
@@ -63,8 +63,8 @@ public class GHAppTest extends AbstractGHAppInstallationTest {
         assertThat(app.getDescription(), is(""));
         assertThat(app.getExternalUrl(), is("http://localhost"));
         assertThat(app.getHtmlUrl().toString(), is("https://github.com/apps/ghapi-test-app-1"));
-        assertThat(app.getCreatedAt(), is(GitHubClient.parseDate("2020-09-30T13:40:56Z")));
-        assertThat(app.getUpdatedAt(), is(GitHubClient.parseDate("2020-09-30T13:40:56Z")));
+        assertThat(app.getCreatedAt(), is(GitHubClient.parseInstant("2020-09-30T13:40:56Z")));
+        assertThat(app.getUpdatedAt(), is(GitHubClient.parseInstant("2020-09-30T13:40:56Z")));
         assertThat(app.getPermissions().size(), is(2));
         assertThat(app.getEvents().size(), is(0));
         assertThat(app.getInstallationsCount(), is((long) 1));
@@ -90,7 +90,7 @@ public class GHAppTest extends AbstractGHAppInstallationTest {
         assertThat(appInstallation.getRequester().getId(), is((long) 195437694));
         assertThat(appInstallation.getRequester().getLogin(), is("kaladinstormblessed2"));
         assertThat(appInstallation.getRequester().getType(), is("User"));
-        assertThat(appInstallation.getCreatedAt(), is(GitHubClient.parseDate("2025-01-17T15:50:51Z")));
+        assertThat(appInstallation.getCreatedAt(), is(GitHubClient.parseInstant("2025-01-17T15:50:51Z")));
         assertThat(appInstallation.getNodeId(), is("MDMwOkludGVncmF0aW9uSW5zdGFsbGF0aW9uUmVxdWVzdDEwMzcyMDQ="));
     }
 
@@ -116,14 +116,10 @@ public class GHAppTest extends AbstractGHAppInstallationTest {
      * @throws IOException
      *             Signals that an I/O exception has occurred.
      *
-     * @throws ParseException
-     *             Issue parsing date string.
      */
     @Test
-    public void listInstallationsSince() throws IOException, ParseException {
-        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd");
-        simpleDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
-        Date localDate = simpleDateFormat.parse("2023-11-01");
+    public void listInstallationsSince() throws IOException {
+        Instant localDate = LocalDate.parse("2023-11-01", DateTimeFormatter.ISO_LOCAL_DATE).atStartOfDay().toInstant(ZoneOffset.UTC);
         GHApp app = gitHub.getApp();
         List<GHAppInstallation> installations = app.listInstallations(localDate).toList();
         assertThat(installations.size(), is(1));
@@ -226,7 +222,7 @@ public class GHAppTest extends AbstractGHAppInstallationTest {
         assertThat(installationToken.getToken(), is("bogus"));
         assertThat(installation.getPermissions(), is(permissions));
         assertThat(installationToken.getRepositorySelection(), is(GHRepositorySelection.SELECTED));
-        assertThat(installationToken.getExpiresAt(), is(GitHubClient.parseDate("2019-08-10T05:54:58Z")));
+        assertThat(installationToken.getExpiresAt(), is(GitHubClient.parseInstant("2019-08-10T05:54:58Z")));
 
         GHRepository repository = installationToken.getRepositories().get(0);
         assertThat(installationToken.getRepositories().size(), is(1));
@@ -239,7 +235,7 @@ public class GHAppTest extends AbstractGHAppInstallationTest {
         assertThat(installationToken2.getToken(), is("bogus"));
         assertThat(installationToken2.getPermissions().size(), is(4));
         assertThat(installationToken2.getRepositorySelection(), is(GHRepositorySelection.ALL));
-        assertThat(installationToken2.getExpiresAt(), is(GitHubClient.parseDate("2019-12-19T12:27:59Z")));
+        assertThat(installationToken2.getExpiresAt(), is(GitHubClient.parseInstant("2019-12-19T12:27:59Z")));
 
         assertThat(installationToken2.getRepositories(), nullValue());;
     }
@@ -263,7 +259,7 @@ public class GHAppTest extends AbstractGHAppInstallationTest {
         assertThat(installationToken.getToken(), is("bogus"));
         assertThat(installationToken.getPermissions().entrySet(), hasSize(4));
         assertThat(installationToken.getRepositorySelection(), is(GHRepositorySelection.SELECTED));
-        assertThat(installationToken.getExpiresAt(), is(GitHubClient.parseDate("2022-07-27T21:38:33Z")));
+        assertThat(installationToken.getExpiresAt(), is(GitHubClient.parseInstant("2022-07-27T21:38:33Z")));
 
         GHRepository repository = installationToken.getRepositories().get(0);
         assertThat(installationToken.getRepositories().size(), is(1));
@@ -295,8 +291,8 @@ public class GHAppTest extends AbstractGHAppInstallationTest {
 
         List<GHEvent> events = Arrays.asList(GHEvent.PULL_REQUEST, GHEvent.PUSH);
         assertThat(appInstallation.getEvents(), containsInAnyOrder(events.toArray(new GHEvent[0])));
-        assertThat(appInstallation.getCreatedAt(), is(GitHubClient.parseDate("2019-07-04T01:19:36.000Z")));
-        assertThat(appInstallation.getUpdatedAt(), is(GitHubClient.parseDate("2019-07-30T22:48:09.000Z")));
+        assertThat(appInstallation.getCreatedAt(), is(GitHubClient.parseInstant("2019-07-04T01:19:36.000Z")));
+        assertThat(appInstallation.getUpdatedAt(), is(GitHubClient.parseInstant("2019-07-30T22:48:09.000Z")));
         assertThat(appInstallation.getSingleFileName(), nullValue());
     }
 

--- a/src/test/java/org/kohsuke/github/GHCheckRunBuilderTest.java
+++ b/src/test/java/org/kohsuke/github/GHCheckRunBuilderTest.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 import org.kohsuke.github.GHCheckRun.Status;
 
 import java.io.IOException;
-import java.util.Date;
+import java.time.Instant;
 
 import static org.hamcrest.Matchers.*;
 
@@ -71,8 +71,8 @@ public class GHCheckRunBuilderTest extends AbstractGHAppInstallationTest {
                 .withConclusion(GHCheckRun.Conclusion.SUCCESS)
                 .withDetailsURL("http://nowhere.net/stuff")
                 .withExternalID("whatever")
-                .withStartedAt(new Date(999_999_000))
-                .withCompletedAt(new Date(999_999_999))
+                .withStartedAt(Instant.ofEpochMilli(999_999_000))
+                .withCompletedAt(Instant.ofEpochMilli(999_999_999))
                 .add(new GHCheckRunBuilder.Output("Some Title", "what happened…").withText("Hello Text!")
                         .add(new GHCheckRunBuilder.Annotation("stuff.txt",
                                 1,
@@ -185,7 +185,7 @@ public class GHCheckRunBuilderTest extends AbstractGHAppInstallationTest {
         GHCheckRun checkRun = getInstallationGithub().getRepository("hub4j-test-org/test-checks")
                 .createCheckRun("foo", "89a9ae301e35e667756034fdc933b1fc94f63fc1")
                 .withStatus(GHCheckRun.Status.IN_PROGRESS)
-                .withStartedAt(new Date(999_999_000))
+                .withStartedAt(Instant.ofEpochMilli(999_999_000))
                 .add(new GHCheckRunBuilder.Output("Some Title", "what happened…")
                         .add(new GHCheckRunBuilder.Annotation("stuff.txt",
                                 1,
@@ -195,9 +195,9 @@ public class GHCheckRunBuilderTest extends AbstractGHAppInstallationTest {
         GHCheckRun updated = checkRun.update()
                 .withStatus(GHCheckRun.Status.COMPLETED)
                 .withConclusion(GHCheckRun.Conclusion.SUCCESS)
-                .withCompletedAt(new Date(999_999_999))
+                .withCompletedAt(Instant.ofEpochMilli(999_999_999))
                 .create();
-        assertThat(new Date(999_999_000), equalTo(updated.getStartedAt()));
+        assertThat(Instant.ofEpochMilli(999_999_000), equalTo(updated.getStartedAt()));
         assertThat("foo", equalTo(updated.getName()));
         assertThat(checkRun.getOutput().getAnnotationsCount(), equalTo(1));
     }
@@ -213,7 +213,7 @@ public class GHCheckRunBuilderTest extends AbstractGHAppInstallationTest {
         GHCheckRun checkRun = getInstallationGithub().getRepository("hub4j-test-org/test-checks")
                 .createCheckRun("foo", "89a9ae301e35e667756034fdc933b1fc94f63fc1")
                 .withStatus(GHCheckRun.Status.IN_PROGRESS)
-                .withStartedAt(new Date(999_999_000))
+                .withStartedAt(Instant.ofEpochMilli(999_999_000))
                 .add(new GHCheckRunBuilder.Output("Some Title", "what happened…")
                         .add(new GHCheckRunBuilder.Annotation("stuff.txt",
                                 1,
@@ -223,10 +223,10 @@ public class GHCheckRunBuilderTest extends AbstractGHAppInstallationTest {
         GHCheckRun updated = checkRun.update()
                 .withStatus(GHCheckRun.Status.COMPLETED)
                 .withConclusion(GHCheckRun.Conclusion.SUCCESS)
-                .withCompletedAt(new Date(999_999_999))
+                .withCompletedAt(Instant.ofEpochMilli(999_999_999))
                 .withName("bar", checkRun.getName())
                 .create();
-        assertThat(new Date(999_999_000), equalTo(updated.getStartedAt()));
+        assertThat(Instant.ofEpochMilli(999_999_000), equalTo(updated.getStartedAt()));
         assertThat("bar", equalTo(updated.getName()));
         assertThat(checkRun.getOutput().getAnnotationsCount(), equalTo(1));
     }
@@ -243,7 +243,7 @@ public class GHCheckRunBuilderTest extends AbstractGHAppInstallationTest {
         GHCheckRun checkRun = getInstallationGithub().getRepository("hub4j-test-org/test-checks")
                 .createCheckRun("foo", "89a9ae301e35e667756034fdc933b1fc94f63fc1")
                 .withStatus(GHCheckRun.Status.IN_PROGRESS)
-                .withStartedAt(new Date(999_999_000))
+                .withStartedAt(Instant.ofEpochMilli(999_999_000))
                 .add(new GHCheckRunBuilder.Output("Some Title", "what happened…")
                         .add(new GHCheckRunBuilder.Annotation("stuff.txt",
                                 1,
@@ -254,7 +254,7 @@ public class GHCheckRunBuilderTest extends AbstractGHAppInstallationTest {
                 () -> checkRun.update()
                         .withStatus(GHCheckRun.Status.COMPLETED)
                         .withConclusion(GHCheckRun.Conclusion.SUCCESS)
-                        .withCompletedAt(new Date(999_999_999))
+                        .withCompletedAt(Instant.ofEpochMilli(999_999_999))
                         .withName("bar", null)
                         .create());
     }

--- a/src/test/java/org/kohsuke/github/GHContentIntegrationTest.java
+++ b/src/test/java/org/kohsuke/github/GHContentIntegrationTest.java
@@ -245,8 +245,8 @@ public class GHContentIntegrationTest extends AbstractGitHubWireMockTest {
         assertThat(mockGitHub.getRequestCount(), equalTo(expectedRequestCount));
 
         assertThat(gitCommit.getMessage(), equalTo("Creating a file for integration tests."));
-        assertThat(gitCommit.getAuthoredDate(), equalTo(GitHubClient.parseDate("2021-06-28T20:37:49Z")));
-        assertThat(gitCommit.getCommitDate(), equalTo(GitHubClient.parseDate("2021-06-28T20:37:49Z")));
+        assertThat(gitCommit.getAuthoredDate(), equalTo(GitHubClient.parseInstant("2021-06-28T20:37:49Z")));
+        assertThat(gitCommit.getCommitDate(), equalTo(GitHubClient.parseInstant("2021-06-28T20:37:49Z")));
 
         assertThat(ghCommit.getCommitShortInfo().getMessage(), equalTo("Creating a file for integration tests."));
         assertThat("Message already resolved", mockGitHub.getRequestCount(), equalTo(expectedRequestCount));
@@ -296,8 +296,8 @@ public class GHContentIntegrationTest extends AbstractGitHubWireMockTest {
         assertThat(mockGitHub.getRequestCount(), equalTo(expectedRequestCount));
 
         assertThat(gitCommit.getMessage(), equalTo("Updated file for integration tests."));
-        assertThat(gitCommit.getAuthoredDate(), equalTo(GitHubClient.parseDate("2021-06-28T20:37:51Z")));
-        assertThat(gitCommit.getCommitDate(), equalTo(GitHubClient.parseDate("2021-06-28T20:37:51Z")));
+        assertThat(gitCommit.getAuthoredDate(), equalTo(GitHubClient.parseInstant("2021-06-28T20:37:51Z")));
+        assertThat(gitCommit.getCommitDate(), equalTo(GitHubClient.parseInstant("2021-06-28T20:37:51Z")));
 
         assertThat(ghCommit.getCommitShortInfo().getMessage(), equalTo("Updated file for integration tests."));
         assertThat("Message already resolved", mockGitHub.getRequestCount(), equalTo(expectedRequestCount));

--- a/src/test/java/org/kohsuke/github/GHDeployKeyTest.java
+++ b/src/test/java/org/kohsuke/github/GHDeployKeyTest.java
@@ -4,7 +4,6 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.time.Instant;
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
@@ -47,13 +46,13 @@ public class GHDeployKeyTest extends AbstractGitHubWireMockTest {
         assertThat("The key exists", ed25519Key, isPresent());
         assertThat("The key was created at the specified date",
                 ed25519Key.get().getCreatedAt(),
-                is(Date.from(Instant.parse("2023-02-08T10:00:15.00Z"))));
+                is(Instant.parse("2023-02-08T10:00:15.00Z")));
         assertThat("The key is created by " + KEY_CREATOR_USERNAME,
                 ed25519Key.get().getAdded_by(),
                 is(KEY_CREATOR_USERNAME));
         assertThat("The key has a last_used value",
                 ed25519Key.get().getLastUsedAt(),
-                is(Date.from(Instant.parse("2023-02-08T10:02:11.00Z"))));
+                is(Instant.parse("2023-02-08T10:02:11.00Z")));
         assertThat("The key only has read access", ed25519Key.get().isRead_only(), is(true));
         assertThat("Object has a toString()", ed25519Key.get().toString(), is(notNullValue()));
 
@@ -63,7 +62,7 @@ public class GHDeployKeyTest extends AbstractGitHubWireMockTest {
         assertThat("The key exists", rsa_4096Key, isPresent());
         assertThat("The key was created at the specified date",
                 rsa_4096Key.get().getCreatedAt(),
-                is(Date.from(Instant.parse("2023-01-26T14:12:12.00Z"))));
+                is(Instant.parse("2023-01-26T14:12:12.00Z")));
         assertThat("The key is created by " + KEY_CREATOR_USERNAME,
                 rsa_4096Key.get().getAdded_by(),
                 is(KEY_CREATOR_USERNAME));

--- a/src/test/java/org/kohsuke/github/GHEventPayloadTest.java
+++ b/src/test/java/org/kohsuke/github/GHEventPayloadTest.java
@@ -9,10 +9,8 @@ import org.kohsuke.github.GHProjectsV2ItemChanges.FieldType;
 import org.kohsuke.github.GHTeam.Privacy;
 
 import java.io.IOException;
-import java.text.SimpleDateFormat;
 import java.util.Collections;
 import java.util.List;
-import java.util.TimeZone;
 
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.contains;
@@ -622,9 +620,7 @@ public class GHEventPayloadTest extends AbstractGitHubWireMockTest {
         assertThat(event.getHeadCommit().getModified().get(0), is("README.md"));
         assertThat(event.getHeadCommit().getMessage(), is("Update README.md"));
 
-        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
-        formatter.setTimeZone(TimeZone.getTimeZone("UTC"));
-        assertThat(formatter.format(event.getCommits().get(0).getTimestamp()), is("2015-05-05T23:40:15Z"));
+        assertThat(GitHubClient.printInstant(event.getCommits().get(0).getTimestamp()), is("2015-05-05T23:40:15Z"));
         assertThat(event.getRepository().getName(), is("public-repo"));
         assertThat(event.getRepository().getOwnerName(), is("baxterthehacker"));
         assertThat(event.getRepository().getUrl().toExternalForm(),
@@ -887,10 +883,8 @@ public class GHEventPayloadTest extends AbstractGitHubWireMockTest {
         assertThat(checkRun.getNodeId(), is("MDg6Q2hlY2tSdW4xMjg2MjAyMjg="));
         assertThat(checkRun.getExternalId(), is(""));
 
-        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
-        formatter.setTimeZone(TimeZone.getTimeZone("UTC"));
-        assertThat(formatter.format(checkRun.getStartedAt()), is("2019-05-15T15:21:12Z"));
-        assertThat(formatter.format(checkRun.getCompletedAt()), is("2019-05-15T20:22:22Z"));
+        assertThat(GitHubClient.printInstant(checkRun.getStartedAt()), is("2019-05-15T15:21:12Z"));
+        assertThat(GitHubClient.printInstant(checkRun.getCompletedAt()), is("2019-05-15T20:22:22Z"));
 
         assertThat(checkRun.getConclusion(), is(Conclusion.SUCCESS));
         assertThat(checkRun.getUrl().toString(), endsWith("/repos/Codertocat/Hello-World/check-runs/128620228"));
@@ -969,9 +963,7 @@ public class GHEventPayloadTest extends AbstractGitHubWireMockTest {
         assertThat(checkSuite.getHeadCommit().getAuthor().getName(), is("Codertocat"));
         assertThat(checkSuite.getHeadCommit().getCommitter().getName(), is("Codertocat"));
 
-        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
-        formatter.setTimeZone(TimeZone.getTimeZone("UTC"));
-        assertThat(formatter.format(checkSuite.getHeadCommit().getTimestamp()), is("2019-05-15T15:20:30Z"));
+        assertThat(GitHubClient.printInstant(checkSuite.getHeadCommit().getTimestamp()), is("2019-05-15T15:20:30Z"));
 
         assertThat(checkSuite.getApp().getId(), is(29310L));
 
@@ -1138,14 +1130,14 @@ public class GHEventPayloadTest extends AbstractGitHubWireMockTest {
                 is("https://api.github.com/repos/gsmet/quarkus-bot-java-playground/actions/runs/680604745/rerun"));
         assertThat(workflowRun.getWorkflowUrl().toString(),
                 is("https://api.github.com/repos/gsmet/quarkus-bot-java-playground/actions/workflows/7087581"));
-        assertThat(workflowRun.getCreatedAt().getTime(), is(1616524526000L));
-        assertThat(workflowRun.getUpdatedAt().getTime(), is(1616524543000L));
+        assertThat(workflowRun.getCreatedAt().toEpochMilli(), is(1616524526000L));
+        assertThat(workflowRun.getUpdatedAt().toEpochMilli(), is(1616524543000L));
         assertThat(workflowRun.getRunAttempt(), is(1L));
-        assertThat(workflowRun.getRunStartedAt().getTime(), is(1616524526000L));
+        assertThat(workflowRun.getRunStartedAt().toEpochMilli(), is(1616524526000L));
         assertThat(workflowRun.getHeadCommit().getId(), is("dbea8d8b6ed2cf764dfd84a215f3f9040b3d4423"));
         assertThat(workflowRun.getHeadCommit().getTreeId(), is("b17089e6a2574ec1002566fe980923e62dce3026"));
         assertThat(workflowRun.getHeadCommit().getMessage(), is("Update main.yml"));
-        assertThat(workflowRun.getHeadCommit().getTimestamp().getTime(), is(1616523390000L));
+        assertThat(workflowRun.getHeadCommit().getTimestamp().toEpochMilli(), is(1616523390000L));
         assertThat(workflowRun.getHeadCommit().getAuthor().getName(), is("Guillaume Smet"));
         assertThat(workflowRun.getHeadCommit().getAuthor().getEmail(), is("guillaume.smet@gmail.com"));
         assertThat(workflowRun.getHeadCommit().getCommitter().getName(), is("GitHub"));
@@ -1219,8 +1211,8 @@ public class GHEventPayloadTest extends AbstractGitHubWireMockTest {
         assertThat(workflowJob.getHeadSha(), is("5dd2dadfbdc2a722c08a8ad42ae4e26e3e731042"));
         assertThat(workflowJob.getStatus(), is(GHWorkflowRun.Status.COMPLETED));
         assertThat(workflowJob.getConclusion(), is(GHWorkflowRun.Conclusion.FAILURE));
-        assertThat(workflowJob.getStartedAt().getTime(), is(1653908125000L));
-        assertThat(workflowJob.getCompletedAt().getTime(), is(1653908157000L));
+        assertThat(workflowJob.getStartedAt().toEpochMilli(), is(1653908125000L));
+        assertThat(workflowJob.getCompletedAt().toEpochMilli(), is(1653908157000L));
         assertThat(workflowJob.getName(), is("JVM Tests - JDK JDK16"));
         assertThat(workflowJob.getSteps(),
                 contains(hasProperty("name", is("Set up job")),
@@ -1325,8 +1317,8 @@ public class GHEventPayloadTest extends AbstractGitHubWireMockTest {
         assertThat(category.getEmoji(), is(":pray:"));
         assertThat(category.getName(), is("Q&A"));
         assertThat(category.getDescription(), is("Ask the community for help"));
-        assertThat(category.getCreatedAt().getTime(), is(1636991431000L));
-        assertThat(category.getUpdatedAt().getTime(), is(1636991431000L));
+        assertThat(category.getCreatedAt().toEpochMilli(), is(1636991431000L));
+        assertThat(category.getUpdatedAt().toEpochMilli(), is(1636991431000L));
         assertThat(category.getSlug(), is("q-a"));
         assertThat(category.isAnswerable(), is(true));
 
@@ -1348,8 +1340,8 @@ public class GHEventPayloadTest extends AbstractGitHubWireMockTest {
         assertThat(discussion.getState(), is(GHRepositoryDiscussion.State.OPEN));
         assertThat(discussion.isLocked(), is(false));
         assertThat(discussion.getComments(), is(0));
-        assertThat(discussion.getCreatedAt().getTime(), is(1637584949000L));
-        assertThat(discussion.getUpdatedAt().getTime(), is(1637584949000L));
+        assertThat(discussion.getCreatedAt().toEpochMilli(), is(1637584949000L));
+        assertThat(discussion.getUpdatedAt().toEpochMilli(), is(1637584949000L));
         assertThat(discussion.getAuthorAssociation(), is(GHCommentAuthorAssociation.OWNER));
         assertThat(discussion.getActiveLockReason(), is(nullValue()));
         assertThat(discussion.getBody(), is("Body of discussion."));
@@ -1379,14 +1371,14 @@ public class GHEventPayloadTest extends AbstractGitHubWireMockTest {
         assertThat(category.getEmoji(), is(":pray:"));
         assertThat(category.getName(), is("Q&A"));
         assertThat(category.getDescription(), is("Ask the community for help"));
-        assertThat(category.getCreatedAt().getTime(), is(1636991431000L));
-        assertThat(category.getUpdatedAt().getTime(), is(1636991431000L));
+        assertThat(category.getCreatedAt().toEpochMilli(), is(1636991431000L));
+        assertThat(category.getUpdatedAt().toEpochMilli(), is(1636991431000L));
         assertThat(category.getSlug(), is("q-a"));
         assertThat(category.isAnswerable(), is(true));
 
         assertThat(discussion.getAnswerHtmlUrl().toString(),
                 is("https://github.com/gsmet/quarkus-bot-java-playground/discussions/78#discussioncomment-1681242"));
-        assertThat(discussion.getAnswerChosenAt().getTime(), is(1637585047000L));
+        assertThat(discussion.getAnswerChosenAt().toEpochMilli(), is(1637585047000L));
         assertThat(discussion.getAnswerChosenBy().getLogin(), is("gsmet"));
 
         assertThat(discussion.getHtmlUrl().toString(),
@@ -1403,8 +1395,8 @@ public class GHEventPayloadTest extends AbstractGitHubWireMockTest {
         assertThat(discussion.getState(), is(GHRepositoryDiscussion.State.OPEN));
         assertThat(discussion.isLocked(), is(false));
         assertThat(discussion.getComments(), is(1));
-        assertThat(discussion.getCreatedAt().getTime(), is(1637584949000L));
-        assertThat(discussion.getUpdatedAt().getTime(), is(1637585047000L));
+        assertThat(discussion.getCreatedAt().toEpochMilli(), is(1637584949000L));
+        assertThat(discussion.getUpdatedAt().toEpochMilli(), is(1637585047000L));
         assertThat(discussion.getAuthorAssociation(), is(GHCommentAuthorAssociation.OWNER));
         assertThat(discussion.getActiveLockReason(), is(nullValue()));
         assertThat(discussion.getBody(), is("Body of discussion."));
@@ -1434,8 +1426,8 @@ public class GHEventPayloadTest extends AbstractGitHubWireMockTest {
         assertThat(category.getEmoji(), is(":pray:"));
         assertThat(category.getName(), is("Q&A"));
         assertThat(category.getDescription(), is("Ask the community for help"));
-        assertThat(category.getCreatedAt().getTime(), is(1636991431000L));
-        assertThat(category.getUpdatedAt().getTime(), is(1636991431000L));
+        assertThat(category.getCreatedAt().toEpochMilli(), is(1636991431000L));
+        assertThat(category.getUpdatedAt().toEpochMilli(), is(1636991431000L));
         assertThat(category.getSlug(), is("q-a"));
         assertThat(category.isAnswerable(), is(true));
 
@@ -1457,8 +1449,8 @@ public class GHEventPayloadTest extends AbstractGitHubWireMockTest {
         assertThat(discussion.getState(), is(GHRepositoryDiscussion.State.OPEN));
         assertThat(discussion.isLocked(), is(false));
         assertThat(discussion.getComments(), is(0));
-        assertThat(discussion.getCreatedAt().getTime(), is(1637584949000L));
-        assertThat(discussion.getUpdatedAt().getTime(), is(1637584961000L));
+        assertThat(discussion.getCreatedAt().toEpochMilli(), is(1637584949000L));
+        assertThat(discussion.getUpdatedAt().toEpochMilli(), is(1637584961000L));
         assertThat(discussion.getAuthorAssociation(), is(GHCommentAuthorAssociation.OWNER));
         assertThat(discussion.getActiveLockReason(), is(nullValue()));
         assertThat(discussion.getBody(), is("Body of discussion."));
@@ -1498,8 +1490,8 @@ public class GHEventPayloadTest extends AbstractGitHubWireMockTest {
         assertThat(category.getEmoji(), is(":pray:"));
         assertThat(category.getName(), is("Q&A"));
         assertThat(category.getDescription(), is("Ask the community for help"));
-        assertThat(category.getCreatedAt().getTime(), is(1636991431000L));
-        assertThat(category.getUpdatedAt().getTime(), is(1636991431000L));
+        assertThat(category.getCreatedAt().toEpochMilli(), is(1636991431000L));
+        assertThat(category.getUpdatedAt().toEpochMilli(), is(1636991431000L));
         assertThat(category.getSlug(), is("q-a"));
         assertThat(category.isAnswerable(), is(true));
 
@@ -1521,8 +1513,8 @@ public class GHEventPayloadTest extends AbstractGitHubWireMockTest {
         assertThat(discussion.getState(), is(GHRepositoryDiscussion.State.OPEN));
         assertThat(discussion.isLocked(), is(false));
         assertThat(discussion.getComments(), is(1));
-        assertThat(discussion.getCreatedAt().getTime(), is(1705586390000L));
-        assertThat(discussion.getUpdatedAt().getTime(), is(1705586399000L));
+        assertThat(discussion.getCreatedAt().toEpochMilli(), is(1705586390000L));
+        assertThat(discussion.getUpdatedAt().toEpochMilli(), is(1705586399000L));
         assertThat(discussion.getAuthorAssociation(), is(GHCommentAuthorAssociation.OWNER));
         assertThat(discussion.getActiveLockReason(), is(nullValue()));
         assertThat(discussion.getBody(), is("Test question"));
@@ -1534,8 +1526,8 @@ public class GHEventPayloadTest extends AbstractGitHubWireMockTest {
         assertThat(comment.getId(), is(8169669L));
         assertThat(comment.getNodeId(), is("DC_kwDOEq3cwc4AfKjF"));
         assertThat(comment.getAuthorAssociation(), is(GHCommentAuthorAssociation.OWNER));
-        assertThat(comment.getCreatedAt().getTime(), is(1705586398000L));
-        assertThat(comment.getUpdatedAt().getTime(), is(1705586399000L));
+        assertThat(comment.getCreatedAt().toEpochMilli(), is(1705586398000L));
+        assertThat(comment.getUpdatedAt().toEpochMilli(), is(1705586399000L));
         assertThat(comment.getBody(), is("Test comment."));
         assertThat(comment.getUser().getLogin(), is("gsmet"));
         assertThat(comment.getUser().getId(), is(1279749L));
@@ -1558,7 +1550,7 @@ public class GHEventPayloadTest extends AbstractGitHubWireMockTest {
         assertThat(starPayload.getAction(), is("created"));
         assertThat(starPayload.getRepository().getFullName(), is("gsmet/quarkus-bot-java-playground"));
         assertThat(starPayload.getSender().getLogin(), is("gsmet"));
-        assertThat(starPayload.getStarredAt().getTime(), is(1654017876000L));
+        assertThat(starPayload.getStarredAt().toEpochMilli(), is(1654017876000L));
     }
 
     /**
@@ -1581,8 +1573,8 @@ public class GHEventPayloadTest extends AbstractGitHubWireMockTest {
         assertThat(projectsV2ItemPayload.getProjectsV2Item().getContentType(), is(ContentType.ISSUE));
         assertThat(projectsV2ItemPayload.getProjectsV2Item().getCreator().getLogin(), is("gsmet"));
         assertThat(projectsV2ItemPayload.getProjectsV2Item().getCreator().getNodeId(), is("MDQ6VXNlcjEyNzk3NDk="));
-        assertThat(projectsV2ItemPayload.getProjectsV2Item().getCreatedAt().getTime(), is(1659532028000L));
-        assertThat(projectsV2ItemPayload.getProjectsV2Item().getUpdatedAt().getTime(), is(1659532028000L));
+        assertThat(projectsV2ItemPayload.getProjectsV2Item().getCreatedAt().toEpochMilli(), is(1659532028000L));
+        assertThat(projectsV2ItemPayload.getProjectsV2Item().getUpdatedAt().toEpochMilli(), is(1659532028000L));
         assertThat(projectsV2ItemPayload.getProjectsV2Item().getArchivedAt(), is(nullValue()));
 
         assertThat(projectsV2ItemPayload.getOrganization().getLogin(), is("gsmet-bot-playground"));
@@ -1612,8 +1604,8 @@ public class GHEventPayloadTest extends AbstractGitHubWireMockTest {
         assertThat(projectsV2ItemPayload.getAction(), is("edited"));
 
         assertThat(projectsV2ItemPayload.getProjectsV2Item().getId(), is(8083254L));
-        assertThat(projectsV2ItemPayload.getProjectsV2Item().getCreatedAt().getTime(), is(1659532028000L));
-        assertThat(projectsV2ItemPayload.getProjectsV2Item().getUpdatedAt().getTime(), is(1659532033000L));
+        assertThat(projectsV2ItemPayload.getProjectsV2Item().getCreatedAt().toEpochMilli(), is(1659532028000L));
+        assertThat(projectsV2ItemPayload.getProjectsV2Item().getUpdatedAt().toEpochMilli(), is(1659532033000L));
         assertThat(projectsV2ItemPayload.getProjectsV2Item().getArchivedAt(), is(nullValue()));
 
         assertThat(projectsV2ItemPayload.getChanges().getFieldValue().getFieldNodeId(),
@@ -1635,12 +1627,12 @@ public class GHEventPayloadTest extends AbstractGitHubWireMockTest {
         assertThat(projectsV2ItemPayload.getAction(), is("archived"));
 
         assertThat(projectsV2ItemPayload.getProjectsV2Item().getId(), is(8083794L));
-        assertThat(projectsV2ItemPayload.getProjectsV2Item().getCreatedAt().getTime(), is(1659532431000L));
-        assertThat(projectsV2ItemPayload.getProjectsV2Item().getUpdatedAt().getTime(), is(1660086629000L));
-        assertThat(projectsV2ItemPayload.getProjectsV2Item().getArchivedAt().getTime(), is(1660086629000L));
+        assertThat(projectsV2ItemPayload.getProjectsV2Item().getCreatedAt().toEpochMilli(), is(1659532431000L));
+        assertThat(projectsV2ItemPayload.getProjectsV2Item().getUpdatedAt().toEpochMilli(), is(1660086629000L));
+        assertThat(projectsV2ItemPayload.getProjectsV2Item().getArchivedAt().toEpochMilli(), is(1660086629000L));
 
         assertThat(projectsV2ItemPayload.getChanges().getArchivedAt().getFrom(), is(nullValue()));
-        assertThat(projectsV2ItemPayload.getChanges().getArchivedAt().getTo().getTime(), is(1660086629000L));
+        assertThat(projectsV2ItemPayload.getChanges().getArchivedAt().getTo().toEpochMilli(), is(1660086629000L));
     }
 
     /**
@@ -1657,11 +1649,11 @@ public class GHEventPayloadTest extends AbstractGitHubWireMockTest {
         assertThat(projectsV2ItemPayload.getAction(), is("restored"));
 
         assertThat(projectsV2ItemPayload.getProjectsV2Item().getId(), is(8083254L));
-        assertThat(projectsV2ItemPayload.getProjectsV2Item().getCreatedAt().getTime(), is(1659532028000L));
-        assertThat(projectsV2ItemPayload.getProjectsV2Item().getUpdatedAt().getTime(), is(1659532419000L));
+        assertThat(projectsV2ItemPayload.getProjectsV2Item().getCreatedAt().toEpochMilli(), is(1659532028000L));
+        assertThat(projectsV2ItemPayload.getProjectsV2Item().getUpdatedAt().toEpochMilli(), is(1659532419000L));
         assertThat(projectsV2ItemPayload.getProjectsV2Item().getArchivedAt(), is(nullValue()));
 
-        assertThat(projectsV2ItemPayload.getChanges().getArchivedAt().getFrom().getTime(), is(1659532142000L));
+        assertThat(projectsV2ItemPayload.getChanges().getArchivedAt().getFrom().toEpochMilli(), is(1659532142000L));
         assertThat(projectsV2ItemPayload.getChanges().getArchivedAt().getTo(), is(nullValue()));
     }
 
@@ -1679,8 +1671,8 @@ public class GHEventPayloadTest extends AbstractGitHubWireMockTest {
         assertThat(projectsV2ItemPayload.getAction(), is("reordered"));
 
         assertThat(projectsV2ItemPayload.getProjectsV2Item().getId(), is(8083794L));
-        assertThat(projectsV2ItemPayload.getProjectsV2Item().getCreatedAt().getTime(), is(1659532431000L));
-        assertThat(projectsV2ItemPayload.getProjectsV2Item().getUpdatedAt().getTime(), is(1659532439000L));
+        assertThat(projectsV2ItemPayload.getProjectsV2Item().getCreatedAt().toEpochMilli(), is(1659532431000L));
+        assertThat(projectsV2ItemPayload.getProjectsV2Item().getUpdatedAt().toEpochMilli(), is(1659532439000L));
         assertThat(projectsV2ItemPayload.getProjectsV2Item().getArchivedAt(), is(nullValue()));
 
         assertThat(projectsV2ItemPayload.getChanges().getPreviousProjectsV2ItemNodeId().getFrom(),

--- a/src/test/java/org/kohsuke/github/GHIssueTest.java
+++ b/src/test/java/org/kohsuke/github/GHIssueTest.java
@@ -5,9 +5,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.time.temporal.ChronoUnit;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import java.util.List;
 
 import static org.hamcrest.Matchers.contains;
@@ -86,9 +85,8 @@ public class GHIssueTest extends AbstractGitHubWireMockTest {
         assertThat(comments, hasSize(0));
 
         GHIssueComment firstComment = issue.comment("First comment");
-        Date firstCommentCreatedAt = firstComment.getCreatedAt();
-        Date firstCommentCreatedAtPlus1Second = Date
-                .from(firstComment.getCreatedAt().toInstant().plus(1, ChronoUnit.SECONDS));
+        Instant firstCommentCreatedAt = firstComment.getCreatedAt();
+        Instant firstCommentCreatedAtPlus1Second = firstComment.getCreatedAt().plusSeconds(1);
 
         comments = issue.listComments().toList();
         assertThat(comments, hasSize(1));
@@ -112,13 +110,12 @@ public class GHIssueTest extends AbstractGitHubWireMockTest {
         Thread.sleep(2000);
 
         GHIssueComment secondComment = issue.comment("Second comment");
-        Date secondCommentCreatedAt = secondComment.getCreatedAt();
-        Date secondCommentCreatedAtPlus1Second = Date
-                .from(secondComment.getCreatedAt().toInstant().plus(1, ChronoUnit.SECONDS));
+        Instant secondCommentCreatedAt = secondComment.getCreatedAt();
+        Instant secondCommentCreatedAtPlus1Second = secondComment.getCreatedAt().plusSeconds(1);
         assertThat(
                 "There's an error in the setup of this test; please fix it."
                         + " The second comment should be created at least one second after the first one.",
-                firstCommentCreatedAtPlus1Second.getTime() <= secondCommentCreatedAt.getTime());
+                firstCommentCreatedAtPlus1Second.isBefore(secondCommentCreatedAt));
 
         comments = issue.listComments().toList();
         assertThat(comments, hasSize(2));
@@ -147,7 +144,7 @@ public class GHIssueTest extends AbstractGitHubWireMockTest {
         assertThat(comments, hasSize(0));
 
         // Test "since" with timestamp instead of Date
-        comments = issue.queryComments().since(secondCommentCreatedAt.getTime()).list().toList();
+        comments = issue.queryComments().since(secondCommentCreatedAt.toEpochMilli()).list().toList();
         assertThat(comments, hasSize(1));
         assertThat(comments, contains(hasProperty("body", equalTo("Second comment"))));
     }

--- a/src/test/java/org/kohsuke/github/GHMilestoneTest.java
+++ b/src/test/java/org/kohsuke/github/GHMilestoneTest.java
@@ -5,7 +5,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.Date;
+import java.time.Instant;
 
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.Matchers.containsString;
@@ -59,8 +59,8 @@ public class GHMilestoneTest extends AbstractGitHubWireMockTest {
 
         String NEW_TITLE = "Updated Title";
         String NEW_DESCRIPTION = "Updated Description";
-        Date NEW_DUE_DATE = GitHubClient.parseDate("2020-10-05T13:00:00Z");
-        Date OUTPUT_DUE_DATE = GitHubClient.parseDate("2020-10-05T07:00:00Z");
+        Instant NEW_DUE_DATE = GitHubClient.parseInstant("2020-10-05T13:00:00Z");
+        Instant OUTPUT_DUE_DATE = GitHubClient.parseInstant("2020-10-05T07:00:00Z");
 
         milestone.setTitle(NEW_TITLE);
         milestone.setDescription(NEW_DESCRIPTION);

--- a/src/test/java/org/kohsuke/github/GHPullRequestTest.java
+++ b/src/test/java/org/kohsuke/github/GHPullRequestTest.java
@@ -6,10 +6,9 @@ import org.junit.Test;
 import org.kohsuke.github.GHPullRequest.AutoMerge;
 
 import java.io.IOException;
-import java.time.temporal.ChronoUnit;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
@@ -135,9 +134,8 @@ public class GHPullRequestTest extends AbstractGitHubWireMockTest {
         assertThat(comments, hasSize(0));
 
         GHIssueComment firstComment = p.comment("First comment");
-        Date firstCommentCreatedAt = firstComment.getCreatedAt();
-        Date firstCommentCreatedAtPlus1Second = Date
-                .from(firstComment.getCreatedAt().toInstant().plus(1, ChronoUnit.SECONDS));
+        Instant firstCommentCreatedAt = firstComment.getCreatedAt();
+        Instant firstCommentCreatedAtPlus1Second = firstComment.getCreatedAt().plusSeconds(1);
 
         comments = p.listComments().toList();
         assertThat(comments, hasSize(1));
@@ -160,13 +158,12 @@ public class GHPullRequestTest extends AbstractGitHubWireMockTest {
         Thread.sleep(2000);
 
         GHIssueComment secondComment = p.comment("Second comment");
-        Date secondCommentCreatedAt = secondComment.getCreatedAt();
-        Date secondCommentCreatedAtPlus1Second = Date
-                .from(secondComment.getCreatedAt().toInstant().plus(1, ChronoUnit.SECONDS));
+        Instant secondCommentCreatedAt = secondComment.getCreatedAt();
+        Instant secondCommentCreatedAtPlus1Second = secondComment.getCreatedAt().plusSeconds(1);
         assertThat(
                 "There's an error in the setup of this test; please fix it."
                         + " The second comment should be created at least one second after the first one.",
-                firstCommentCreatedAtPlus1Second.getTime() <= secondCommentCreatedAt.getTime());
+                firstCommentCreatedAtPlus1Second.isBefore(secondCommentCreatedAt));
 
         comments = p.listComments().toList();
         assertThat(comments, hasSize(2));
@@ -195,7 +192,7 @@ public class GHPullRequestTest extends AbstractGitHubWireMockTest {
         assertThat(comments, hasSize(0));
 
         // Test "since" with timestamp instead of Date
-        comments = p.queryComments().since(secondCommentCreatedAt.getTime()).list().toList();
+        comments = p.queryComments().since(secondCommentCreatedAt.toEpochMilli()).list().toList();
         assertThat(comments, hasSize(1));
         assertThat(comments, contains(hasProperty("body", equalTo("Second comment"))));
     }

--- a/src/test/java/org/kohsuke/github/GHRateLimitTest.java
+++ b/src/test/java/org/kohsuke/github/GHRateLimitTest.java
@@ -7,7 +7,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.time.Duration;
-import java.util.Date;
+import java.time.Instant;
 import java.util.HashMap;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -231,7 +231,7 @@ public class GHRateLimitTest extends AbstractGitHubWireMockTest {
         assertThat(rateLimit.getRemaining(), equalTo(remaining));
 
         // Check that the reset date of the current limit is not older than the previous one
-        long diffMillis = rateLimit.getResetDate().getTime() - previousLimit.getResetDate().getTime();
+        long diffMillis = rateLimit.getResetDate().toEpochMilli() - previousLimit.getResetDate().toEpochMilli();
 
         assertThat(diffMillis, greaterThanOrEqualTo(0L));
         if (changedResetDate) {
@@ -262,7 +262,7 @@ public class GHRateLimitTest extends AbstractGitHubWireMockTest {
         assertThat(mockGitHub.getRequestCount(), equalTo(0));
         GHRateLimit rateLimit = null;
 
-        Date lastReset = new Date(System.currentTimeMillis() / 1000L);
+        Instant lastReset = Instant.ofEpochMilli(System.currentTimeMillis() / 1000L);
 
         // Give this a moment
         Thread.sleep(1500);

--- a/src/test/java/org/kohsuke/github/GHRepositoryTest.java
+++ b/src/test/java/org/kohsuke/github/GHRepositoryTest.java
@@ -15,6 +15,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -262,7 +263,7 @@ public class GHRepositoryTest extends AbstractGitHubWireMockTest {
         repository = gitHub.getOrganization("hub4j").getRepository("github-api");
         Iterable<GHStargazer> stargazers = repository.listStargazers2();
         GHStargazer stargazer = stargazers.iterator().next();
-        assertThat(stargazer.getStarredAt(), equalTo(new Date(1271650383000L)));
+        assertThat(stargazer.getStarredAt(), equalTo(Instant.ofEpochMilli(1271650383000L)));
         assertThat(stargazer.getUser().getLogin(), equalTo("nielswind"));
         assertThat(stargazer.getRepository(), sameInstance(repository));
     }
@@ -314,7 +315,7 @@ public class GHRepositoryTest extends AbstractGitHubWireMockTest {
             assertThat(s.getUrl().toString(), containsString("/repos/hub4j-test-org/github-api/subscription"));
 
             assertThat(s.getReason(), nullValue());
-            assertThat(s.getCreatedAt(), equalTo(new Date(1611377286000L)));
+            assertThat(s.getCreatedAt(), equalTo(Instant.ofEpochMilli(1611377286000L)));
         } finally {
             s.delete();
         }

--- a/src/test/java/org/kohsuke/github/GHTreeBuilderTest.java
+++ b/src/test/java/org/kohsuke/github/GHTreeBuilderTest.java
@@ -5,8 +5,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Arrays;
-import java.util.Date;
 
 import static org.hamcrest.Matchers.*;
 
@@ -146,8 +146,8 @@ public class GHTreeBuilderTest extends AbstractGitHubWireMockTest {
         String treeSha = treeBuilder.create().getSha();
         GHCommit commit = new GHCommitBuilder(repo).message("Add files")
                 .tree(treeSha)
-                .author("author", "author@author.com", new Date(1611433225969L))
-                .committer("committer", "committer@committer.com", new Date(1611433225968L))
+                .author("author", "author@author.com", Instant.ofEpochMilli(1611433225969L))
+                .committer("committer", "committer@committer.com", Instant.ofEpochMilli(1611433225968L))
                 .parent(mainRef.getObject().getSha())
                 .create();
 

--- a/src/test/java/org/kohsuke/github/GHUserTest.java
+++ b/src/test/java/org/kohsuke/github/GHUserTest.java
@@ -247,7 +247,7 @@ public class GHUserTest extends AbstractGitHubWireMockTest {
         assertThat(normal.getSuspendedAt(), is(nullValue()));
 
         GHUser suspended = gitHub.getUser("suspended");
-        Date suspendedAt = new Date(Instant.parse("2024-08-08T00:00:00Z").toEpochMilli());
+        Instant suspendedAt = Instant.ofEpochMilli(Instant.parse("2024-08-08T00:00:00Z").toEpochMilli());
         assertThat(suspended.getSuspendedAt(), equalTo(suspendedAt));
     }
 }

--- a/src/test/java/org/kohsuke/github/GHWorkflowRunTest.java
+++ b/src/test/java/org/kohsuke/github/GHWorkflowRunTest.java
@@ -14,7 +14,6 @@ import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.Scanner;
@@ -290,26 +289,26 @@ public class GHWorkflowRunTest extends AbstractGitHubWireMockTest {
         assertThat(mainBranchHeadShaWorkflowRuns, everyItem(hasProperty("headSha", equalTo(mainBranchHeadSha))));
         // Ideally, we would use everyItem() but the bridge method is in the way
         for (GHWorkflowRun workflowRun : mainBranchHeadShaWorkflowRuns) {
-            assertThat(workflowRun.getCreatedAt(), greaterThanOrEqualTo(Date.from(before)));
+            assertThat(workflowRun.getCreatedAt(), greaterThanOrEqualTo(before));
         }
 
         assertThat(secondBranchHeadShaWorkflowRuns, hasSize(greaterThanOrEqualTo(1)));
         assertThat(secondBranchHeadShaWorkflowRuns, everyItem(hasProperty("headSha", equalTo(secondBranchHeadSha))));
         // Ideally, we would use everyItem() but the bridge method is in the way
         for (GHWorkflowRun workflowRun : secondBranchHeadShaWorkflowRuns) {
-            assertThat(workflowRun.getCreatedAt(), greaterThanOrEqualTo(Date.from(before)));
+            assertThat(workflowRun.getCreatedAt(), greaterThanOrEqualTo(before));
         }
 
         List<GHWorkflowRun> mainBranchHeadShaWorkflowRunsBefore = repo.queryWorkflowRuns()
                 .headSha(repo.getBranch(MAIN_BRANCH).getSHA1())
-                .created("<" + before.toString())
+                .created("<" + before)
                 .list()
                 .toList();
         // Ideally, we would use that but the bridge method is causing issues
         // assertThat(mainBranchHeadShaWorkflowRunsBefore, everyItem(hasProperty("createdAt",
         // lessThan(Date.from(before)))));
         for (GHWorkflowRun workflowRun : mainBranchHeadShaWorkflowRunsBefore) {
-            assertThat(workflowRun.getCreatedAt(), lessThan(Date.from(before)));
+            assertThat(workflowRun.getCreatedAt(), lessThan(before));
         }
     }
 

--- a/src/test/java/org/kohsuke/github/RateLimitCheckerTest.java
+++ b/src/test/java/org/kohsuke/github/RateLimitCheckerTest.java
@@ -57,6 +57,7 @@ public class RateLimitCheckerTest extends AbstractGitHubWireMockTest {
         // Give this a moment
         Thread.sleep(1000);
 
+        //noinspection UseOfObsoleteDateTimeApi
         templating.testStartDate = new Date();
         // -------------------------------------------------------------
         // /user gets response with rate limit information


### PR DESCRIPTION
# Description

Migrates the legacy date-time api to newer date-time api introduced in JSR 310.

Fixes #2073

Did not introduce any new tests for this, as no new functionality was introduced, only updated the previous tests to use `Instant` instead of `Date`.

Several methods with `date` in the name were renamed to instead have `instant` in the name. All of these methods are package-private or only accessible to the tests.

# Before submitting a PR:

- [x] ~~Changes must not break binary backwards compatibility. If you are unclear on how to make the change you think is needed while maintaining backward compatibility, [CONTRIBUTING.md](CONTRIBUTING.md) for details.~~ These changes break binary backwards compatibility, however this is meant for new 2.x release.
- [x] Add JavaDocs and other comments explaining the behavior. 
- [x] When adding or updating methods that fetch entities, add `@link` JavaDoc entries to the relevant documentation on https://docs.github.com/en/rest . 
- [x] Add tests that cover any added or changed code. This generally requires capturing snapshot test data. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [x] Run `mvn -D enable-ci clean install site "-Dsurefire.argLine=--add-opens java.base/java.net=ALL-UNNAMED"` locally. If this command doesn't succeed, your change will not pass CI.
- [x] Push your changes to a branch other than `main`. You will create your PR from that branch.

# When creating a PR: 

- [x] Fill in the "Description" above with clear summary of the changes. This includes:
  - [x] If this PR fixes one or more issues, include "Fixes #<issue number>" lines for each issue. 
  - [x] Provide links to relevant documentation on https://docs.github.com/en/rest where possible. If not including links, explain why not.
- [x] All lines of new code should be covered by tests as reported by code coverage. Any lines that are not covered must have PR comments explaining why they cannot be covered. For example, "Reaching this particular exception is hard and is not a particular common scenario."
- [x] Enable "Allow edits from maintainers".
