### PR TITLE
Re-enable japicmp enforcement

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Maven Install (skipTests)
       env:
         MAVEN_OPTS: ${{ env.JAVA_11_PLUS_MAVEN_OPTS }}
-      run: mvn -B clean install -Djapicmp.skip=true -DskipTests --file pom.xml
+      run: mvn -B clean install -DskipTests --file pom.xml
     - uses: actions/upload-artifact@v4
       with:
         name: maven-target-directory
@@ -59,7 +59,7 @@ jobs:
         MAVEN_OPTS: ${{ env.JAVA_11_PLUS_MAVEN_OPTS }}
       # running install site seems to more closely imitate real site deployment,
       # more likely to prevent failed deployment
-      run: mvn -B clean install site -Djapicmp.skip=true -DskipTests --file pom.xml
+      run: mvn -B clean install site -DskipTests --file pom.xml
   test-bridged:
     name: build-and-test Bridged (Java 17)
     # Does not require build output, but orders execution to prevent launching test workflows when simple build fails 
@@ -78,8 +78,7 @@ jobs:
     - name: Maven Install (skipTests)
       env:
         MAVEN_OPTS: ${{ env.JAVA_11_PLUS_MAVEN_OPTS }}
-      #skipping japicmp check for bridged artifact until after next release
-      run: mvn -B clean install -Djapicmp.skip=true -Pbridged -D enable-ci --file pom.xml "-Dsurefire.argLine=--add-opens java.base/java.net=ALL-UNNAMED"
+      run: mvn -B clean install -Pbridged -D enable-ci --file pom.xml "-Dsurefire.argLine=--add-opens java.base/java.net=ALL-UNNAMED"
   test:
     name: test (${{ matrix.os }}, Java ${{ matrix.java }})
     # Does not require build output, but orders execution to prevent launching test workflows when simple build fails 
@@ -108,8 +107,7 @@ jobs:
       if: matrix.os != 'windows'
       env:
         MAVEN_OPTS: ${{ env.JAVA_11_PLUS_MAVEN_OPTS }}
-      # Disable japicmp until next release
-      run: mvn -B clean install -Djapicmp.skip=true -D enable-ci --file pom.xml "-Dsurefire.argLine=--add-opens java.base/java.net=ALL-UNNAMED"
+      run: mvn -B clean install -D enable-ci --file pom.xml "-Dsurefire.argLine=--add-opens java.base/java.net=ALL-UNNAMED"
     - name: Save coverage data
       if: matrix.os == 'ubuntu' && matrix.java == '17'
       uses: actions/upload-artifact@v4

--- a/.github/workflows/publish_release_branch.yml
+++ b/.github/workflows/publish_release_branch.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Maven Install and Site with Code Coverage
         env:
           MAVEN_OPTS: ${{ env.JAVA_11_PLUS_MAVEN_OPTS }}
-        run: mvn -B clean install site -Djapicmp.skip=true -D enable-ci --file pom.xml "-Dsurefire.argLine=--add-opens java.base/java.net=ALL-UNNAMED"
+        run: mvn -B clean install site -D enable-ci --file pom.xml "-Dsurefire.argLine=--add-opens java.base/java.net=ALL-UNNAMED"
 
       - uses: actions/upload-artifact@v4
         with:
@@ -49,7 +49,7 @@ jobs:
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
       - name: Publish package
-        run: mvn -B clean deploy -Djapicmp.skip=true -DskipTests -Prelease
+        run: mvn -B clean deploy -DskipTests -Prelease
         env:
           MAVEN_OPTS: ${{ env.JAVA_11_PLUS_MAVEN_OPTS }}
           MAVEN_USERNAME: ${{ secrets.OSSRH_TOKEN_USERNAME }}
@@ -57,7 +57,7 @@ jobs:
           MAVEN_GPG_PASSPHRASE: ${{ secrets.OSSRH_GPG_SECRET_KEY_PASSPHRASE }}
 
       - name: Publish package with bridge methods 
-        run: mvn -B clean deploy -Djapicmp.skip=true -DskipTests -Prelease -Pbridged
+        run: mvn -B clean deploy -DskipTests -Prelease -Pbridged
         env:
           MAVEN_OPTS: ${{ env.JAVA_11_PLUS_MAVEN_OPTS }}
           MAVEN_USERNAME: ${{ secrets.OSSRH_TOKEN_USERNAME }}


### PR DESCRIPTION
# Description

<!-- Describe your change here -->

# Before submitting a PR:

- [ ] Changes must not break binary backwards compatibility. If you are unclear on how to make the change you think is needed while maintaining backward compatibility, [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [ ] Add JavaDocs and other comments explaining the behavior. 
- [ ] When adding or updating methods that fetch entities, add `@link` JavaDoc entries to the relevant documentation on https://docs.github.com/en/rest . 
- [ ] Add tests that cover any added or changed code. This generally requires capturing snapshot test data. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [ ] Run `mvn -D enable-ci clean install site "-Dsurefire.argLine=--add-opens java.base/java.net=ALL-UNNAMED"` locally. If this command doesn't succeed, your change will not pass CI.
- [ ] Push your changes to a branch other than `main`. You will create your PR from that branch.

# When creating a PR: 

- [ ] Fill in the "Description" above with clear summary of the changes. This includes:
  - [ ] If this PR fixes one or more issues, include "Fixes #<issue number>" lines for each issue. 
  - [ ] Provide links to relevant documentation on https://docs.github.com/en/rest where possible. If not including links, explain why not.
- [ ] All lines of new code should be covered by tests as reported by code coverage. Any lines that are not covered must have PR comments explaining why they cannot be covered. For example, "Reaching this particular exception is hard and is not a particular common scenario."
- [ ] Enable "Allow edits from maintainers".
