### PR TITLE
Add polymorphic deserialization for the GHAppInstallation account field

### DIFF
--- a/src/main/java/org/kohsuke/github/GHAppInstallation.java
+++ b/src/main/java/org/kohsuke/github/GHAppInstallation.java
@@ -1,6 +1,8 @@
 package org.kohsuke.github;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.kohsuke.github.internal.EnumUtils;
@@ -39,7 +41,10 @@ public class GHAppInstallation extends GHObject {
     @JsonProperty("access_tokens_url")
     private String accessTokenUrl;
 
-    private GHUser account;
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+    @JsonSubTypes({ @JsonSubTypes.Type(value = GHUser.class, name = "User"),
+            @JsonSubTypes.Type(value = GHOrganization.class, name = "Organization") })
+    private GHPerson account;
     @JsonProperty("app_id")
     private long appId;
     private List<String> events;
@@ -122,7 +127,7 @@ public class GHAppInstallation extends GHObject {
      * @return the account
      */
     @SuppressFBWarnings(value = { "EI_EXPOSE_REP" }, justification = "Expected behavior")
-    public GHUser getAccount() {
+    public GHPerson getAccount() {
         return account;
     }
 

--- a/src/test/java/org/kohsuke/github/AppTest.java
+++ b/src/test/java/org/kohsuke/github/AppTest.java
@@ -737,6 +737,7 @@ public class AppTest extends AbstractGitHubWireMockTest {
         final GHAppInstallation ghAppInstallation = appInstallation.toList().get(0);
         assertThat(ghAppInstallation.getAppId(), is(122478L));
         assertThat(ghAppInstallation.getAccount().getLogin(), is("t0m4uk1991"));
+        assertThat(ghAppInstallation.getAccount(), instanceOf(GHUser.class));
     }
 
     /**

--- a/src/test/java/org/kohsuke/github/GHAppTest.java
+++ b/src/test/java/org/kohsuke/github/GHAppTest.java
@@ -264,11 +264,12 @@ public class GHAppTest extends AbstractGHAppInstallationTest {
 
     private void testAppInstallation(GHAppInstallation appInstallation) throws IOException {
         Map<String, GHPermissionType> appPermissions = appInstallation.getPermissions();
-        GHUser appAccount = appInstallation.getAccount();
+        GHPerson appAccount = appInstallation.getAccount();
 
         assertThat(appInstallation.getId(), is((long) 11111111));
         assertThat(appAccount.getId(), is((long) 111111111));
         assertThat(appAccount.login, is("bogus"));
+        assertThat(appAccount, instanceOf(GHOrganization.class));
         assertThat(appAccount.getType(), is("Organization"));
         assertThat(appInstallation.getRepositorySelection(), is(GHRepositorySelection.SELECTED));
         assertThat(appInstallation.getAccessTokenUrl(), endsWith("/app/installations/11111111/access_tokens"));

--- a/src/test/java/org/kohsuke/github/GHEventPayloadTest.java
+++ b/src/test/java/org/kohsuke/github/GHEventPayloadTest.java
@@ -18,6 +18,7 @@ import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.hasToString;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.notNullValue;
@@ -59,6 +60,8 @@ public class GHEventPayloadTest extends AbstractGitHubWireMockTest {
         assertThat(event.getAction(), is("created"));
         assertThat(event.getInstallation().getId(), is(43898337L));
         assertThat(event.getInstallation().getAccount().getLogin(), is("CronFire"));
+        assertThat(event.getInstallation().getAccount(), instanceOf(GHOrganization.class));
+        assertThat(event.getInstallation().getAccount().getType(), is("Organization"));
 
         assertThat(event.getRepositories().isEmpty(), is(false));
         assertThat(event.getRepositories().get(0).getId(), is(1296269L));
@@ -84,6 +87,8 @@ public class GHEventPayloadTest extends AbstractGitHubWireMockTest {
         assertThat(event.getAction(), is("deleted"));
         assertThat(event.getInstallation().getId(), is(2L));
         assertThat(event.getInstallation().getAccount().getLogin(), is("octocat"));
+        assertThat(event.getInstallation().getAccount(), instanceOf(GHUser.class));
+        assertThat(event.getInstallation().getAccount().getType(), is("User"));
 
         assertThrows(IllegalStateException.class, () -> event.getRepositories().isEmpty());
         assertThat(event.getRawRepositories().isEmpty(), is(false));


### PR DESCRIPTION
# Description
Fixes #1497 
Recovering PR #1522 
There is a problem: this works fine for events, but when deserializing App Installation GET API responses, the `type` field (based on which we identify whether the `account` is User or Org) gets unset to `null`. The `account` polymorphic deserialization part works fine though. Perhaps there is a difference in how we are using Jackson at both places (events vs regular API responses), but I have not been able to figure it out yet. 
<!-- Describe your change here -->

# Before submitting a PR:

- [ ] Changes must not break binary backwards compatibility. If you are unclear on how to make the change you think is needed while maintaining backward compatibility, [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [ ] Add JavaDocs and other comments explaining the behavior. 
- [ ] When adding or updating methods that fetch entities, add `@link` JavaDoc entries to the relevant documentation on https://docs.github.com/en/rest . 
- [ ] Add tests that cover any added or changed code. This generally requires capturing snapshot test data. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [ ] Run `mvn -D enable-ci clean install site "-Dsurefire.argLine=--add-opens java.base/java.net=ALL-UNNAMED"` locally. If this command doesn't succeed, your change will not pass CI.
- [ ] Push your changes to a branch other than `main`. You will create your PR from that branch.

# When creating a PR: 

- [ ] Fill in the "Description" above with clear summary of the changes. This includes:
  - [ ] If this PR fixes one or more issues, include "Fixes #<issue number>" lines for each issue. 
  - [ ] Provide links to relevant documentation on https://docs.github.com/en/rest where possible. If not including links, explain why not.
- [ ] All lines of new code should be covered by tests as reported by code coverage. Any lines that are not covered must have PR comments explaining why they cannot be covered. For example, "Reaching this particular exception is hard and is not a particular common scenario."
- [ ] Enable "Allow edits from maintainers".
