### PR TITLE
Add workflow run query builder for specific workflow

### DIFF
--- a/src/main/java/org/kohsuke/github/GHWorkflow.java
+++ b/src/main/java/org/kohsuke/github/GHWorkflow.java
@@ -156,6 +156,16 @@ public class GHWorkflow extends GHObject {
         return new GHWorkflowRunsIterable(owner, root().createRequest().withUrlPath(getApiRoute(), "runs"));
     }
 
+    /**
+     * Workflow run query builder for this workflow.
+     *
+     * @return the GHWorkflowRunQueryBuilder instance for querying runs
+     */
+    public GHWorkflowRunQueryBuilder queryRuns() {
+        return new GHWorkflowRunQueryBuilder(this);
+
+    }
+
     private String getApiRoute() {
         if (owner == null) {
             // Workflow runs returned from search to do not have an owner. Attempt to use url.

--- a/src/main/java/org/kohsuke/github/GHWorkflowRunQueryBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHWorkflowRunQueryBuilder.java
@@ -11,6 +11,7 @@ import org.kohsuke.github.GHWorkflowRun.Status;
  * @see GHRepository#queryWorkflowRuns()
  */
 public class GHWorkflowRunQueryBuilder extends GHQueryBuilder<GHWorkflowRun> {
+    private final GHWorkflow ghWorkflow;
     private final GHRepository repo;
 
     /**
@@ -22,6 +23,19 @@ public class GHWorkflowRunQueryBuilder extends GHQueryBuilder<GHWorkflowRun> {
     GHWorkflowRunQueryBuilder(GHRepository repo) {
         super(repo.root());
         this.repo = repo;
+        this.ghWorkflow = null;
+    }
+
+    /**
+     * Instantiates a new GH workflow run query builder for a specific workflow.
+     *
+     * @param ghWorkflow
+     *            the ghWorkflow
+     */
+    GHWorkflowRunQueryBuilder(GHWorkflow ghWorkflow) {
+        super(ghWorkflow.getRepository().root());
+        this.repo = ghWorkflow.getRepository();
+        this.ghWorkflow = ghWorkflow;
     }
 
     /**
@@ -133,7 +147,12 @@ public class GHWorkflowRunQueryBuilder extends GHQueryBuilder<GHWorkflowRun> {
      */
     @Override
     public PagedIterable<GHWorkflowRun> list() {
-        return new GHWorkflowRunsIterable(repo, req.withUrlPath(repo.getApiTailUrl("actions/runs")));
+        if (ghWorkflow != null) {
+            req.withUrlPath(repo.getApiTailUrl("actions/workflows"), String.valueOf(ghWorkflow.getId()), "runs");
+        } else {
+            req.withUrlPath(repo.getApiTailUrl("actions/runs"));
+        }
+        return new GHWorkflowRunsIterable(repo, req);
     }
 
     /**

--- a/src/test/java/org/kohsuke/github/GHWorkflowRunTest.java
+++ b/src/test/java/org/kohsuke/github/GHWorkflowRunTest.java
@@ -148,14 +148,20 @@ public class GHWorkflowRunTest extends AbstractGitHubWireMockTest {
             String workflowName,
             String branch,
             Conclusion conclusion) {
-        List<GHWorkflowRun> workflowRuns = repository.queryWorkflowRuns()
-                .branch(branch)
-                .conclusion(conclusion)
-                .event(GHEvent.PULL_REQUEST)
-                .list()
-                .withPageSize(20)
-                .iterator()
-                .nextPage();
+        List<GHWorkflowRun> workflowRuns;
+        try {
+            workflowRuns = repository.getWorkflow(workflowName)
+                    .queryRuns()
+                    .branch(branch)
+                    .conclusion(conclusion)
+                    .event(GHEvent.PULL_REQUEST)
+                    .list()
+                    .withPageSize(20)
+                    .iterator()
+                    .nextPage();
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to get workflow run", e);
+        }
 
         for (GHWorkflowRun workflowRun : workflowRuns) {
             if (workflowRun.getName().equals(workflowName)) {


### PR DESCRIPTION
# Description

Currently the `GHWorkflowRunQueryBuilder` is only available in `GHRepository` which does not allow to use the query builder for a specific workflow.

By adding it to `GHWorkflow` and extend the `GHWorkflowRunQueryBuilder` to also be usable for a specific workflow id one can query a specific workflow, being more efficient
