### PR TITLE
Add missing properties to GHAsset and GHRelease

### DIFF
--- a/src/main/java/org/kohsuke/github/GHAsset.java
+++ b/src/main/java/org/kohsuke/github/GHAsset.java
@@ -143,6 +143,7 @@ public class GHAsset extends GHObject {
      *
      * @return the uploader
      */
+    @SuppressFBWarnings(value = { "EI_EXPOSE_REP" }, justification = "Expected behavior")
     public GHPerson getUploader() {
         return uploader;
     }

--- a/src/main/java/org/kohsuke/github/GHAsset.java
+++ b/src/main/java/org/kohsuke/github/GHAsset.java
@@ -30,11 +30,13 @@ public class GHAsset extends GHObject {
 
     private String browserDownloadUrl;
     private String contentType;
+    private String digest;
     private long downloadCount;
     private String label;
     private String name;
     private long size;
     private String state;
+    private GHUser uploader;
     /** The owner. */
     GHRepository owner;
 
@@ -70,6 +72,15 @@ public class GHAsset extends GHObject {
      */
     public String getContentType() {
         return contentType;
+    }
+
+    /**
+     * Gets the digest.
+     *
+     * @return the digest
+     */
+    public String getDigest() {
+        return digest;
     }
 
     /**
@@ -125,6 +136,15 @@ public class GHAsset extends GHObject {
      */
     public String getState() {
         return state;
+    }
+
+    /**
+     * Gets uploader.
+     *
+     * @return the uploader
+     */
+    public GHPerson getUploader() {
+        return uploader;
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHRelease.java
+++ b/src/main/java/org/kohsuke/github/GHRelease.java
@@ -43,10 +43,14 @@ public class GHRelease extends GHObject {
     private List<GHAsset> assets;
 
     private String assetsUrl;
+    private GHUser author;
     private String body;
+    private String bodyHtml;
+    private String bodyText;
     private String discussionUrl;
     private boolean draft;
     private String htmlUrl;
+    private int mentionsCount;
     private String name;
     private boolean prerelease;
     private String publishedAt;
@@ -93,12 +97,39 @@ public class GHRelease extends GHObject {
     }
 
     /**
+     * Gets the author.
+     *
+     * @return the author
+     */
+    public GHUser getAuthor() {
+        return author;
+    }
+
+    /**
      * Gets body.
      *
      * @return the body
      */
     public String getBody() {
         return body;
+    }
+
+    /**
+     * Gets body html.
+     *
+     * @return the body html
+     */
+    public String getBodyHtml() {
+        return bodyHtml;
+    }
+
+    /**
+     * Gets body text.
+     *
+     * @return the body text
+     */
+    public String getBodyText() {
+        return bodyText;
     }
 
     /**
@@ -117,6 +148,10 @@ public class GHRelease extends GHObject {
      */
     public URL getHtmlUrl() {
         return GitHubClient.parseURL(htmlUrl);
+    }
+
+    public int getMentionsCount() {
+        return this.mentionsCount;
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHRelease.java
+++ b/src/main/java/org/kohsuke/github/GHRelease.java
@@ -101,6 +101,7 @@ public class GHRelease extends GHObject {
      *
      * @return the author
      */
+    @SuppressFBWarnings(value = { "EI_EXPOSE_REP" }, justification = "Expected behavior")
     public GHUser getAuthor() {
         return author;
     }


### PR DESCRIPTION
# Description

Adds missing fields for the `GHAsset` and `GHRelease` classes.
See: https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28

I didn't bother adding tests because it's just new fields/getters. 

Fixes #2102

# Before submitting a PR:

- [x] Changes must not break binary backwards compatibility. If you are unclear on how to make the change you think is needed while maintaining backward compatibility, [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [x] Add JavaDocs and other comments explaining the behavior. 
- [ ] When adding or updating methods that fetch entities, add `@link` JavaDoc entries to the relevant documentation on https://docs.github.com/en/rest . 
- [ ] Add tests that cover any added or changed code. This generally requires capturing snapshot test data. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [x] Run `mvn -D enable-ci clean install site "-Dsurefire.argLine=--add-opens java.base/java.net=ALL-UNNAMED"` locally. If this command doesn't succeed, your change will not pass CI.
- [x] Push your changes to a branch other than `main`. You will create your PR from that branch.

# When creating a PR: 

- [x] Fill in the "Description" above with clear summary of the changes. This includes:
  - [x] If this PR fixes one or more issues, include "Fixes #<issue number>" lines for each issue. 
  - [x] Provide links to relevant documentation on https://docs.github.com/en/rest where possible. If not including links, explain why not.
- [x] All lines of new code should be covered by tests as reported by code coverage. Any lines that are not covered must have PR comments explaining why they cannot be covered. For example, "Reaching this particular exception is hard and is not a particular common scenario."
- [x] Enable "Allow edits from maintainers".
