### PR TITLE
Make `isError` on GitHubConnectorResponseErrorHandler public.

### DIFF
--- a/src/main/java/org/kohsuke/github/GitHubAbuseLimitHandler.java
+++ b/src/main/java/org/kohsuke/github/GitHubAbuseLimitHandler.java
@@ -107,7 +107,7 @@ public abstract class GitHubAbuseLimitHandler extends GitHubConnectorResponseErr
      *             Signals that an I/O exception has occurred.
      */
     @Override
-    public boolean isError(@Nonnull GitHubConnectorResponse connectorResponse) {
+    public boolean isError(@Nonnull GitHubConnectorResponse connectorResponse) throws IOException {
         return isTooManyRequests(connectorResponse)
                 || (isForbidden(connectorResponse) && hasRetryOrLimitHeader(connectorResponse));
     }

--- a/src/main/java/org/kohsuke/github/GitHubAbuseLimitHandler.java
+++ b/src/main/java/org/kohsuke/github/GitHubAbuseLimitHandler.java
@@ -178,7 +178,7 @@ public abstract class GitHubAbuseLimitHandler extends GitHubConnectorResponseErr
      *             Signals that an I/O exception has occurred.
      */
     @Override
-    boolean isError(@Nonnull GitHubConnectorResponse connectorResponse) {
+    public boolean isError(@Nonnull GitHubConnectorResponse connectorResponse) {
         return isTooManyRequests(connectorResponse)
                 || (isForbidden(connectorResponse) && hasRetryOrLimitHeader(connectorResponse));
     }

--- a/src/main/java/org/kohsuke/github/GitHubAbuseLimitHandler.java
+++ b/src/main/java/org/kohsuke/github/GitHubAbuseLimitHandler.java
@@ -98,6 +98,21 @@ public abstract class GitHubAbuseLimitHandler extends GitHubConnectorResponseErr
     }
 
     /**
+     * Checks if is error.
+     *
+     * @param connectorResponse
+     *            the connector response
+     * @return true, if is error
+     * @throws IOException
+     *             Signals that an I/O exception has occurred.
+     */
+    @Override
+    public boolean isError(@Nonnull GitHubConnectorResponse connectorResponse) {
+        return isTooManyRequests(connectorResponse)
+                || (isForbidden(connectorResponse) && hasRetryOrLimitHeader(connectorResponse));
+    }
+
+    /**
      * Called when the library encounters HTTP error indicating that the API abuse limit is reached.
      *
      * <p>
@@ -166,21 +181,6 @@ public abstract class GitHubAbuseLimitHandler extends GitHubConnectorResponseErr
      */
     private boolean isTooManyRequests(GitHubConnectorResponse connectorResponse) {
         return connectorResponse.statusCode() == TOO_MANY_REQUESTS;
-    }
-
-    /**
-     * Checks if is error.
-     *
-     * @param connectorResponse
-     *            the connector response
-     * @return true, if is error
-     * @throws IOException
-     *             Signals that an I/O exception has occurred.
-     */
-    @Override
-    public boolean isError(@Nonnull GitHubConnectorResponse connectorResponse) {
-        return isTooManyRequests(connectorResponse)
-                || (isForbidden(connectorResponse) && hasRetryOrLimitHeader(connectorResponse));
     }
 
 }

--- a/src/main/java/org/kohsuke/github/GitHubConnectorResponseErrorHandler.java
+++ b/src/main/java/org/kohsuke/github/GitHubConnectorResponseErrorHandler.java
@@ -110,5 +110,5 @@ abstract class GitHubConnectorResponseErrorHandler {
      * @throws IOException
      *             Signals that an I/O exception has occurred.
      */
-    abstract boolean isError(@Nonnull GitHubConnectorResponse connectorResponse) throws IOException;
+    public abstract boolean isError(@Nonnull GitHubConnectorResponse connectorResponse) throws IOException;
 }

--- a/src/main/java/org/kohsuke/github/GitHubConnectorResponseErrorHandler.java
+++ b/src/main/java/org/kohsuke/github/GitHubConnectorResponseErrorHandler.java
@@ -85,6 +85,17 @@ abstract class GitHubConnectorResponseErrorHandler {
     };
 
     /**
+     * Called to detect an error handled by this handler.
+     *
+     * @param connectorResponse
+     *            the connector response
+     * @return {@code true} if there is an error and {@link #onError(GitHubConnectorResponse)} should be called
+     * @throws IOException
+     *             Signals that an I/O exception has occurred.
+     */
+    public abstract boolean isError(@Nonnull GitHubConnectorResponse connectorResponse) throws IOException;
+
+    /**
      * Called when the library encounters HTTP error matching {@link #isError(GitHubConnectorResponse)}
      *
      * <p>
@@ -100,15 +111,4 @@ abstract class GitHubConnectorResponseErrorHandler {
      * @see <a href="https://developer.github.com/v3/#rate-limiting">API documentation from GitHub</a>
      */
     public abstract void onError(@Nonnull GitHubConnectorResponse connectorResponse) throws IOException;
-
-    /**
-     * Called to detect an error handled by this handler.
-     *
-     * @param connectorResponse
-     *            the connector response
-     * @return {@code true} if there is an error and {@link #onError(GitHubConnectorResponse)} should be called
-     * @throws IOException
-     *             Signals that an I/O exception has occurred.
-     */
-    public abstract boolean isError(@Nonnull GitHubConnectorResponse connectorResponse) throws IOException;
 }

--- a/src/main/java/org/kohsuke/github/GitHubRateLimitHandler.java
+++ b/src/main/java/org/kohsuke/github/GitHubRateLimitHandler.java
@@ -91,7 +91,7 @@ public abstract class GitHubRateLimitHandler extends GitHubConnectorResponseErro
      *             Signals that an I/O exception has occurred.
      */
     @Override
-    boolean isError(@NotNull GitHubConnectorResponse connectorResponse) throws IOException {
+    public boolean isError(@NotNull GitHubConnectorResponse connectorResponse) throws IOException {
         return connectorResponse.statusCode() == HTTP_FORBIDDEN
                 && "0".equals(connectorResponse.header("X-RateLimit-Remaining"));
     }

--- a/src/main/java/org/kohsuke/github/GitHubRateLimitHandler.java
+++ b/src/main/java/org/kohsuke/github/GitHubRateLimitHandler.java
@@ -65,6 +65,21 @@ public abstract class GitHubRateLimitHandler extends GitHubConnectorResponseErro
     }
 
     /**
+     * Checks if is error.
+     *
+     * @param connectorResponse
+     *            the connector response
+     * @return true, if is error
+     * @throws IOException
+     *             Signals that an I/O exception has occurred.
+     */
+    @Override
+    public boolean isError(@NotNull GitHubConnectorResponse connectorResponse) throws IOException {
+        return connectorResponse.statusCode() == HTTP_FORBIDDEN
+                && "0".equals(connectorResponse.header("X-RateLimit-Remaining"));
+    }
+
+    /**
      * Called when the library encounters HTTP error indicating that the API rate limit has been exceeded.
      *
      * <p>
@@ -80,21 +95,6 @@ public abstract class GitHubRateLimitHandler extends GitHubConnectorResponseErro
      * @see <a href="https://developer.github.com/v3/#rate-limiting">API documentation from GitHub</a>
      */
     public abstract void onError(@Nonnull GitHubConnectorResponse connectorResponse) throws IOException;
-
-    /**
-     * Checks if is error.
-     *
-     * @param connectorResponse
-     *            the connector response
-     * @return true, if is error
-     * @throws IOException
-     *             Signals that an I/O exception has occurred.
-     */
-    @Override
-    public boolean isError(@NotNull GitHubConnectorResponse connectorResponse) throws IOException {
-        return connectorResponse.statusCode() == HTTP_FORBIDDEN
-                && "0".equals(connectorResponse.header("X-RateLimit-Remaining"));
-    }
 
     /*
      * Exposed for testability. Given an http response, find the rate limit reset header field and parse it. If no


### PR DESCRIPTION
# Description

Changes the access modifier on GithubConnectorResponseErrorHandler and subclasses to public. This allows library users to overwrite what constitutes an error for the response, particularly for (secondary) rate limiting.

Relates to #2009, where GithubAbuseLimitHandler is not properly detecting secondary rate limits but users cannot manually override it while the method is package-private. Additionally, the definition of `isError` under `STATUS_HTTP_BAD_REQUEST_OR_GREATER` is public, which could imply that this should be public from the start. A future PR will do a fix to the underlying issue, but in the mean time this would allow users to implement their own fix.

# Before submitting a PR:

- [x] Changes must not break binary backwards compatibility. If you are unclear on how to make the change you think is needed while maintaining backward compatibility, [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [x] Add JavaDocs and other comments explaining the behavior. 
- [x] When adding or updating methods that fetch entities, add `@link` JavaDoc entries to the relevant documentation on https://docs.github.com/en/rest . 
- [x] Add tests that cover any added or changed code. This generally requires capturing snapshot test data. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [x] Run `mvn -D enable-ci clean install site "-Dsurefire.argLine=--add-opens java.base/java.net=ALL-UNNAMED"` locally. If this command doesn't succeed, your change will not pass CI.
- [x] Push your changes to a branch other than `main`. You will create your PR from that branch.

# When creating a PR: 

- [x] Fill in the "Description" above with clear summary of the changes. This includes:
  - [x] If this PR fixes one or more issues, include "Fixes #<issue number>" lines for each issue. 
  - [x] Provide links to relevant documentation on https://docs.github.com/en/rest where possible. If not including links, explain why not.
- [x] All lines of new code should be covered by tests as reported by code coverage. Any lines that are not covered must have PR comments explaining why they cannot be covered. For example, "Reaching this particular exception is hard and is not a particular common scenario."
- [x] Enable "Allow edits from maintainers".
