### PR TITLE
Deprecate GHRepository#getIssues()

### DIFF
--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -1603,7 +1603,9 @@ public class GHRepository extends GHObject {
      * @return the issues
      * @throws IOException
      *             the io exception
+     * @deprecated Use {@link #queryIssues()} instead.
      */
+    @Deprecated
     public List<GHIssue> getIssues(GHIssueState state) throws IOException {
         return queryIssues().state(state).list().toList();
     }
@@ -1618,7 +1620,9 @@ public class GHRepository extends GHObject {
      * @return the issues
      * @throws IOException
      *             the io exception
+     * @deprecated Use {@link #queryIssues()} instead.
      */
+    @Deprecated
     public List<GHIssue> getIssues(GHIssueState state, GHMilestone milestone) throws IOException {
         return queryIssues().milestone(milestone == null ? "none" : "" + milestone.getNumber())
                 .state(state)


### PR DESCRIPTION
GHRepository#getIssues() has poor performance for large response sets and works against the best usage patterns.   Deprecated in favor of #queryIssues().

Closes #2128

# Description

<!-- Describe your change here -->

# Before submitting a PR:

- [ ] Changes must not break binary backwards compatibility. If you are unclear on how to make the change you think is needed while maintaining backward compatibility, [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [ ] Add JavaDocs and other comments explaining the behavior. 
- [ ] When adding or updating methods that fetch entities, add `@link` JavaDoc entries to the relevant documentation on https://docs.github.com/en/rest . 
- [ ] Add tests that cover any added or changed code. This generally requires capturing snapshot test data. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [ ] Run `mvn -D enable-ci clean install site "-Dsurefire.argLine=--add-opens java.base/java.net=ALL-UNNAMED"` locally. If this command doesn't succeed, your change will not pass CI.
- [ ] Push your changes to a branch other than `main`. You will create your PR from that branch.

# When creating a PR: 

- [ ] Fill in the "Description" above with clear summary of the changes. This includes:
  - [ ] If this PR fixes one or more issues, include "Fixes #<issue number>" lines for each issue. 
  - [ ] Provide links to relevant documentation on https://docs.github.com/en/rest where possible. If not including links, explain why not.
- [ ] All lines of new code should be covered by tests as reported by code coverage. Any lines that are not covered must have PR comments explaining why they cannot be covered. For example, "Reaching this particular exception is hard and is not a particular common scenario."
- [ ] Enable "Allow edits from maintainers".
