### PR TITLE
Support Jackson 2.20+ removal of PropertyNamingStrategy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/main/java/org/kohsuke/github/GitHubClient.java
+++ b/src/main/java/org/kohsuke/github/GitHubClient.java
@@ -2,6 +2,7 @@ package org.kohsuke.github;
 
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.introspect.VisibilityChecker;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.apache.commons.io.IOUtils;
 import org.kohsuke.github.authorization.AuthorizationProvider;
@@ -109,19 +110,21 @@ class GitHubClient {
     /** The Constant DEFAULT_MINIMUM_RETRY_TIMEOUT_MILLIS. */
     private static final int DEFAULT_MINIMUM_RETRY_MILLIS = DEFAULT_MAXIMUM_RETRY_MILLIS;
     private static final Logger LOGGER = Logger.getLogger(GitHubClient.class.getName());
-    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final ObjectMapper MAPPER = buildObjectMapper();
 
     private static final ThreadLocal<String> sendRequestTraceId = new ThreadLocal<>();
 
     /** The Constant GITHUB_URL. */
     static final String GITHUB_URL = "https://api.github.com";
 
-    static {
-        MAPPER.registerModule(new JavaTimeModule());
-        MAPPER.setVisibility(new VisibilityChecker.Std(NONE, NONE, NONE, NONE, ANY));
-        MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        MAPPER.configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS, true);
-        MAPPER.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
+    private static ObjectMapper buildObjectMapper() {
+        return JsonMapper.builder()
+                .addModule(new JavaTimeModule())
+                .visibility(new VisibilityChecker.Std(NONE, NONE, NONE, NONE, ANY))
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS, true)
+                .propertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+                .build();
     }
 
     @Nonnull


### PR DESCRIPTION
# Description

This change requires Jackson `2.12.0` or later.  This change is technically breaking but 5+ years old. 

https://github.com/FasterXML/jackson-databind/commit/9f97baa28c31b450b6fde22ae56e067dd50c2eb4

Fixes #2137 

# Before submitting a PR:

- [ ] Changes must not break binary backwards compatibility. If you are unclear on how to make the change you think is needed while maintaining backward compatibility, [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [ ] Add JavaDocs and other comments explaining the behavior. 
- [ ] When adding or updating methods that fetch entities, add `@link` JavaDoc entries to the relevant documentation on https://docs.github.com/en/rest . 
- [ ] Add tests that cover any added or changed code. This generally requires capturing snapshot test data. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [ ] Run `mvn -D enable-ci clean install site "-Dsurefire.argLine=--add-opens java.base/java.net=ALL-UNNAMED"` locally. If this command doesn't succeed, your change will not pass CI.
- [ ] Push your changes to a branch other than `main`. You will create your PR from that branch.

# When creating a PR: 

- [ ] Fill in the "Description" above with clear summary of the changes. This includes:
  - [ ] If this PR fixes one or more issues, include "Fixes #<issue number>" lines for each issue. 
  - [ ] Provide links to relevant documentation on https://docs.github.com/en/rest where possible. If not including links, explain why not.
- [ ] All lines of new code should be covered by tests as reported by code coverage. Any lines that are not covered must have PR comments explaining why they cannot be covered. For example, "Reaching this particular exception is hard and is not a particular common scenario."
- [ ] Enable "Allow edits from maintainers".
