### PR TITLE
feat: add force-cancel workflow run

### DIFF
--- a/src/main/java/org/kohsuke/github/GHWorkflowRun.java
+++ b/src/main/java/org/kohsuke/github/GHWorkflowRun.java
@@ -209,6 +209,7 @@ public class GHWorkflowRun extends GHObject {
     }
     private GHUser actor;
     private String artifactsUrl;
+    private String forceCancelUrl;
     private String cancelUrl;
     private String checkSuiteUrl;
 
@@ -265,6 +266,16 @@ public class GHWorkflowRun extends GHObject {
      */
     public void cancel() throws IOException {
         root().createRequest().method("POST").withUrlPath(getApiRoute(), "cancel").send();
+    }
+
+    /**
+     * Force-cancel the workflow run.
+     *
+     * @throws IOException
+     *             the io exception
+     */
+    public void forceCancel() throws IOException {
+        root().createRequest().method("POST").withUrlPath(getApiRoute(), "force-cancel").send();
     }
 
     /**
@@ -334,6 +345,15 @@ public class GHWorkflowRun extends GHObject {
      */
     public URL getCancelUrl() {
         return GitHubClient.parseURL(cancelUrl);
+    }
+
+    /**
+     * The cancel URL, like https://api.github.com/repos/octo-org/octo-repo/actions/runs/30433642/force-cancel
+     *
+     * @return the cancel url
+     */
+    public URL getForceCancelUrl() {
+        return GitHubClient.parseURL(forceCancelUrl);
     }
 
     /**

--- a/src/test/java/org/kohsuke/github/GHEventPayloadTest.java
+++ b/src/test/java/org/kohsuke/github/GHEventPayloadTest.java
@@ -1795,6 +1795,8 @@ public class GHEventPayloadTest extends AbstractGitHubWireMockTest {
                 is("https://api.github.com/repos/gsmet/quarkus-bot-java-playground/check-suites/2327154397"));
         assertThat(workflowRun.getArtifactsUrl().toString(),
                 is("https://api.github.com/repos/gsmet/quarkus-bot-java-playground/actions/runs/680604745/artifacts"));
+        assertThat(workflowRun.getForceCancelUrl().toString(),
+                is("https://api.github.com/repos/gsmet/quarkus-bot-java-playground/actions/runs/680604745/force-cancel"));
         assertThat(workflowRun.getCancelUrl().toString(),
                 is("https://api.github.com/repos/gsmet/quarkus-bot-java-playground/actions/runs/680604745/cancel"));
         assertThat(workflowRun.getRerunUrl().toString(),

--- a/src/test/java/org/kohsuke/github/GHWorkflowRunTest.java
+++ b/src/test/java/org/kohsuke/github/GHWorkflowRunTest.java
@@ -421,6 +421,46 @@ public class GHWorkflowRunTest extends AbstractGitHubWireMockTest {
     }
 
     /**
+     * Test force cancel a run.
+     *
+     * @throws IOException
+     *             Signals that an I/O exception has occurred.
+     */
+    @Test
+    public void testForceCancel() throws IOException {
+        GHWorkflow workflow = repo.getWorkflow(SLOW_WORKFLOW_PATH);
+
+        long latestPreexistingWorkflowRunId = getLatestPreexistingWorkflowRunId();
+
+        workflow.dispatch(MAIN_BRANCH);
+
+        // now that we have triggered the workflow run, we will wait until it's in progress and then force cancel it
+        await((nonRecordingRepo) -> getWorkflowRun(nonRecordingRepo,
+                SLOW_WORKFLOW_NAME,
+                MAIN_BRANCH,
+                Status.IN_PROGRESS,
+                latestPreexistingWorkflowRunId).isPresent());
+
+        GHWorkflowRun workflowRun = getWorkflowRun(SLOW_WORKFLOW_NAME,
+                MAIN_BRANCH,
+                Status.IN_PROGRESS,
+                latestPreexistingWorkflowRunId)
+                .orElseThrow(() -> new IllegalStateException("We must have a valid workflow run starting from here"));
+
+        assertThat(workflowRun.getId(), notNullValue());
+
+        workflowRun.forceCancel();
+        long cancelledWorkflowRunId = workflowRun.getId();
+
+        // let's wait until it's completed
+        await((nonRecordingRepo) -> getWorkflowRunStatus(nonRecordingRepo, cancelledWorkflowRunId) == Status.COMPLETED);
+
+        // let's check that it has been properly cancelled
+        workflowRun = repo.getWorkflowRun(cancelledWorkflowRunId);
+        assertThat(workflowRun.getConclusion(), equalTo(Conclusion.CANCELLED));
+    }
+
+    /**
      * Test delete.
      *
      * @throws IOException
@@ -591,6 +631,7 @@ public class GHWorkflowRunTest extends AbstractGitHubWireMockTest {
         assertThat(workflowRun.getCheckSuiteUrl().getPath(), containsString("/check-suites/"));
         assertThat(workflowRun.getArtifactsUrl().getPath(), endsWith("/artifacts"));
         assertThat(workflowRun.getCancelUrl().getPath(), endsWith("/cancel"));
+        assertThat(workflowRun.getForceCancelUrl().getPath(), endsWith("/force-cancel"));
         assertThat(workflowRun.getRerunUrl().getPath(), endsWith("/rerun"));
         assertThat(workflowRun.getWorkflowUrl().getPath(), containsString("/actions/workflows/"));
         assertThat(workflowRun.getHeadBranch(), equalTo(MAIN_BRANCH));

--- a/src/test/java/org/kohsuke/github/GHWorkflowTest.java
+++ b/src/test/java/org/kohsuke/github/GHWorkflowTest.java
@@ -35,6 +35,7 @@ public class GHWorkflowTest extends AbstractGitHubWireMockTest {
         assertThat(workflowRun.getCheckSuiteUrl().getPath(), containsString("/check-suites/"));
         assertThat(workflowRun.getArtifactsUrl().getPath(), endsWith("/artifacts"));
         assertThat(workflowRun.getCancelUrl().getPath(), endsWith("/cancel"));
+        assertThat(workflowRun.getForceCancelUrl().getPath(), endsWith("/force-cancel"));
         assertThat(workflowRun.getRerunUrl().getPath(), endsWith("/rerun"));
         assertThat(workflowRun.getWorkflowUrl().getPath(), containsString("/actions/workflows/"));
         assertThat(workflowRun.getHeadBranch(), equalTo("main"));


### PR DESCRIPTION
# Description

Pretty similar to the existing `cancel` method, but the forced version provided by Github: https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#force-cancel-a-workflow-run

We've been using this library extensively and we have a valid use case for force-cancel. This way we don't have go navigate around the library just for this request.

# Before submitting a PR:

- [x] Changes must not break binary backwards compatibility. If you are unclear on how to make the change you think is needed while maintaining backward compatibility, [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [x] Add JavaDocs and other comments explaining the behavior. 
- [x] When adding or updating methods that fetch entities, add `@link` JavaDoc entries to the relevant documentation on https://docs.github.com/en/rest . 
- [ ] Add tests that cover any added or changed code. This generally requires capturing snapshot test data. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [ ] Run `mvn -D enable-ci clean install site "-Dsurefire.argLine=--add-opens java.base/java.net=ALL-UNNAMED"` locally. If this command doesn't succeed, your change will not pass CI.
- [ ] Push your changes to a branch other than `main`. You will create your PR from that branch.

# When creating a PR: 

- [ ] Fill in the "Description" above with clear summary of the changes. This includes:
  - [ ] If this PR fixes one or more issues, include "Fixes #<issue number>" lines for each issue. 
  - [ ] Provide links to relevant documentation on https://docs.github.com/en/rest where possible. If not including links, explain why not.
- [ ] All lines of new code should be covered by tests as reported by code coverage. Any lines that are not covered must have PR comments explaining why they cannot be covered. For example, "Reaching this particular exception is hard and is not a particular common scenario."
- [ ] Enable "Allow edits from maintainers".
