### PR TITLE
Move to Jackson 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,13 +87,6 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>com.fasterxml.jackson</groupId>
-        <artifactId>jackson-bom</artifactId>
-        <version>2.20.0</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
         <version>5.13.4</version>
@@ -113,6 +106,19 @@
         <version>${spring.boot.version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>tools.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>3.0.3</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <!-- Jackson 3.0 requires jackson-annotations 2.20 -->
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-annotations</artifactId>
+        <version>2.20</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>
@@ -138,14 +144,6 @@
   </dependencyManagement>
 
   <dependencies>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-jsr310</artifactId>
-    </dependency>
     <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
@@ -195,6 +193,10 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <version>3.19.0</version>
+    </dependency>
+    <dependency>
+      <groupId>tools.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
       <groupId>com.github.npathai</groupId>

--- a/src/main/java/org/kohsuke/github/EnterpriseManagedSupport.java
+++ b/src/main/java/org/kohsuke/github/EnterpriseManagedSupport.java
@@ -1,6 +1,6 @@
 package org.kohsuke.github;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
+import tools.jackson.core.JacksonException;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -20,7 +20,7 @@ class EnterpriseManagedSupport {
 
     static final String TEAM_CANNOT_BE_EXTERNALLY_MANAGED_ERROR = "This team cannot be externally managed since it has explicit members.";
 
-    private static String logUnexpectedFailure(final JsonProcessingException exception, final String payload) {
+    private static String logUnexpectedFailure(final JacksonException exception, final String payload) {
         final StringWriter sw = new StringWriter();
         final PrintWriter pw = new PrintWriter(sw);
         exception.printStackTrace(pw);
@@ -58,7 +58,7 @@ class EnterpriseManagedSupport {
                 } else if (TEAM_CANNOT_BE_EXTERNALLY_MANAGED_ERROR.equals(error.getMessage())) {
                     return Optional.of(new GHTeamCannotBeExternallyManagedException(scenario, error, he));
                 }
-            } catch (final JsonProcessingException e) {
+            } catch (final JacksonException e) {
                 // We can ignore it
                 LOGGER.warning(() -> logUnexpectedFailure(e, responseMessage));
             }

--- a/src/main/java/org/kohsuke/github/GHEventInfo.java
+++ b/src/main/java/org/kohsuke/github/GHEventInfo.java
@@ -1,8 +1,8 @@
 package org.kohsuke.github;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import tools.jackson.databind.node.ObjectNode;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -174,7 +174,7 @@ public class GHEventInfo extends GitHubInteractiveObject {
      *             if payload cannot be parsed
      */
     public <T extends GHEventPayload> T getPayload(Class<T> type) throws IOException {
-        T v = GitHubClient.getMappingObjectReader(root()).readValue(payload.traverse(), type);
+        T v = GitHubClient.getMappingObjectReader(root()).forType(type).readValue(payload);
         v.lateBind();
         return v;
     }

--- a/src/main/java/org/kohsuke/github/GHRepositoryRule.java
+++ b/src/main/java/org/kohsuke/github/GHRepositoryRule.java
@@ -1,9 +1,9 @@
 package org.kohsuke.github;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonNode;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.kohsuke.github.internal.EnumUtils;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.JsonNode;
 
 import java.io.IOException;
 import java.util.List;

--- a/src/main/java/org/kohsuke/github/GHRepositoryStatistics.java
+++ b/src/main/java/org/kohsuke/github/GHRepositoryStatistics.java
@@ -1,8 +1,8 @@
 package org.kohsuke.github;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import tools.jackson.databind.exc.MismatchedInputException;
 
 import java.io.IOException;
 import java.util.Arrays;

--- a/src/main/java/org/kohsuke/github/GitHub.java
+++ b/src/main/java/org/kohsuke/github/GitHub.java
@@ -23,13 +23,13 @@
  */
 package org.kohsuke.github;
 
-import com.fasterxml.jackson.databind.ObjectReader;
-import com.fasterxml.jackson.databind.ObjectWriter;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.kohsuke.github.authorization.AuthorizationProvider;
 import org.kohsuke.github.authorization.ImmutableAuthorizationProvider;
 import org.kohsuke.github.authorization.UserAuthorizationProvider;
 import org.kohsuke.github.connector.GitHubConnector;
+import tools.jackson.databind.ObjectReader;
+import tools.jackson.databind.ObjectWriter;
 
 import java.io.*;
 import java.util.*;

--- a/src/main/java/org/kohsuke/github/GitHubResponse.java
+++ b/src/main/java/org/kohsuke/github/GitHubResponse.java
@@ -1,10 +1,9 @@
 package org.kohsuke.github;
 
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.InjectableValues;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import org.apache.commons.io.IOUtils;
 import org.kohsuke.github.connector.GitHubConnectorResponse;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.InjectableValues;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -99,10 +98,10 @@ class GitHubResponse<T> {
             inject.addValue(GitHubConnectorResponse.class, connectorResponse);
 
             return GitHubClient.getMappingObjectReader(connectorResponse).forType(type).readValue(data);
-        } catch (JsonMappingException | JsonParseException e) {
+        } catch (JacksonException e) {
             String message = "Failed to deserialize: " + data;
             LOGGER.log(Level.FINE, message);
-            throw e;
+            throw new IOException(message, e);
         }
     }
 
@@ -125,10 +124,10 @@ class GitHubResponse<T> {
         String data = getBodyAsString(connectorResponse);
         try {
             return GitHubClient.getMappingObjectReader(connectorResponse).withValueToUpdate(instance).readValue(data);
-        } catch (JsonMappingException | JsonParseException e) {
+        } catch (JacksonException e) {
             String message = "Failed to deserialize: " + data;
             LOGGER.log(Level.FINE, message);
-            throw e;
+            throw new IOException(message, e);
         }
     }
 

--- a/src/test/java/org/kohsuke/github/AotIntegrationTest.java
+++ b/src/test/java/org/kohsuke/github/AotIntegrationTest.java
@@ -1,10 +1,10 @@
 package org.kohsuke.github;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
 import org.junit.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.ArrayNode;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -80,7 +80,9 @@ public class AotIntegrationTest {
 
     private Stream<String> readAotConfigToStreamOfClassNames(String reflectionConfig) throws IOException {
         byte[] reflectionConfigFileAsBytes = Files.readAllBytes(Path.of(reflectionConfig));
-        ArrayNode reflectConfigJsonArray = (ArrayNode) new ObjectMapper().readTree(reflectionConfigFileAsBytes);
+        ArrayNode reflectConfigJsonArray = (ArrayNode) JsonMapper.builder()
+                .build()
+                .readTree(reflectionConfigFileAsBytes);
         return StreamSupport
                 .stream(Spliterators.spliteratorUnknownSize(reflectConfigJsonArray.iterator(), Spliterator.ORDERED),
                         false)

--- a/src/test/java/org/kohsuke/github/GHRateLimitTest.java
+++ b/src/test/java/org/kohsuke/github/GHRateLimitTest.java
@@ -1,9 +1,9 @@
 package org.kohsuke.github;
 
-import com.fasterxml.jackson.databind.exc.MismatchedInputException;
-import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import org.junit.Test;
+import tools.jackson.databind.exc.MismatchedInputException;
+import tools.jackson.databind.exc.ValueInstantiationException;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -440,8 +440,10 @@ public class GHRateLimitTest extends AbstractGitHubWireMockTest {
             fail("Invalid rate limit missing some records should throw");
         } catch (Exception e) {
             assertThat(e, instanceOf(HttpException.class));
-            assertThat(e.getCause(), instanceOf(ValueInstantiationException.class));
-            assertThat(e.getCause().getMessage(),
+            // In Jackson 3, the exception is wrapped in IOException
+            assertThat(e.getCause(), instanceOf(IOException.class));
+            assertThat(e.getCause().getCause(), instanceOf(ValueInstantiationException.class));
+            assertThat(e.getCause().getCause().getMessage(),
                     containsString(
                             "Cannot construct instance of `org.kohsuke.github.GHRateLimit`, problem: `java.lang.NullPointerException`"));
         }
@@ -451,8 +453,10 @@ public class GHRateLimitTest extends AbstractGitHubWireMockTest {
             fail("Invalid rate limit record missing a value should throw");
         } catch (Exception e) {
             assertThat(e, instanceOf(HttpException.class));
-            assertThat(e.getCause(), instanceOf(MismatchedInputException.class));
-            assertThat(e.getCause().getMessage(),
+            // In Jackson 3, the exception is wrapped in IOException
+            assertThat(e.getCause(), instanceOf(IOException.class));
+            assertThat(e.getCause().getCause(), instanceOf(MismatchedInputException.class));
+            assertThat(e.getCause().getCause().getMessage(),
                     containsString("Missing required creator property 'reset' (index 2)"));
         }
 

--- a/src/test/java/org/kohsuke/github/GHRepositoryTest.java
+++ b/src/test/java/org/kohsuke/github/GHRepositoryTest.java
@@ -1,6 +1,5 @@
 package org.kohsuke.github;
 
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.google.common.collect.Sets;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.io.IOUtils;
@@ -9,6 +8,7 @@ import org.junit.Test;
 import org.kohsuke.github.GHCheckRun.Conclusion;
 import org.kohsuke.github.GHOrganization.RepositoryRole;
 import org.kohsuke.github.GHRepository.Visibility;
+import tools.jackson.databind.DatabindException;
 
 import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
@@ -1039,7 +1039,9 @@ public class GHRepositoryTest extends AbstractGitHubWireMockTest {
             fail();
         } catch (Exception e) {
             assertThat(e, instanceOf(HttpException.class));
-            assertThat(e.getCause(), instanceOf(JsonMappingException.class));
+            // In Jackson 3, DatabindException is wrapped in IOException
+            assertThat(e.getCause(), instanceOf(IOException.class));
+            assertThat(e.getCause().getCause(), instanceOf(DatabindException.class));
         }
 
         // git/refs/heads/gh

--- a/src/test/java/org/kohsuke/github/connector/GitHubConnectorResponseTest.java
+++ b/src/test/java/org/kohsuke/github/connector/GitHubConnectorResponseTest.java
@@ -1,6 +1,5 @@
 package org.kohsuke.github.connector;
 
-import com.fasterxml.jackson.databind.util.ByteBufferBackedInputStream;
 import org.apache.commons.io.IOUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -8,6 +7,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.kohsuke.github.AbstractGitHubWireMockTest;
 import org.kohsuke.github.connector.GitHubConnectorResponse.ByteArrayResponse;
+import tools.jackson.databind.util.ByteBufferBackedInputStream;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;

--- a/src/test/java/org/kohsuke/github/internal/graphql/response/GHGraphQLResponseMockTest.java
+++ b/src/test/java/org/kohsuke/github/internal/graphql/response/GHGraphQLResponseMockTest.java
@@ -1,11 +1,11 @@
 package org.kohsuke.github.internal.graphql.response;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectReader;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.ObjectReader;
+import tools.jackson.databind.json.JsonMapper;
 
 import java.util.List;
 
@@ -19,11 +19,10 @@ import static org.hamcrest.Matchers.is;
  */
 class GHGraphQLResponseMockTest {
 
-    private GHGraphQLResponse<Object> convertJsonToGraphQLResponse(String json) throws JsonProcessingException {
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    private GHGraphQLResponse<Object> convertJsonToGraphQLResponse(String json) throws JacksonException {
+        JsonMapper mapper = JsonMapper.builder().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES).build();
 
-        ObjectReader objectReader = objectMapper.reader();
+        ObjectReader objectReader = mapper.reader();
         JavaType javaType = objectReader.getTypeFactory()
                 .constructParametricType(GHGraphQLResponse.class, Object.class);
 
@@ -33,12 +32,12 @@ class GHGraphQLResponseMockTest {
     /**
      * Test get data throws exception when response means error
      *
-     * @throws JsonProcessingException
+     * @throws JacksonException
      *             Json parse exception
      *
      */
     @Test
-    void getDataFailure() throws JsonProcessingException {
+    void getDataFailure() throws JacksonException {
         String graphQLErrorResponse = "{\"data\": {\"enablePullRequestAutoMerge\": null},\"errors\": [{\"type\": "
                 + "\"UNPROCESSABLE\",\"path\": [\"enablePullRequestAutoMerge\"],\"locations\": [{\"line\": 2,"
                 + "\"column\": 5}],\"message\": \"hub4j does not have a verified email, which is required to enable "
@@ -56,11 +55,11 @@ class GHGraphQLResponseMockTest {
     /**
      * Test getErrorMessages throws exception when response means not error
      *
-     * @throws JsonProcessingException
+     * @throws JacksonException
      *             Json parse exception
      */
     @Test
-    void getErrorMessagesFailure() throws JsonProcessingException {
+    void getErrorMessagesFailure() throws JacksonException {
         String graphQLSuccessResponse = "{\"data\": {\"repository\": {\"pullRequest\": {\"id\": "
                 + "\"PR_TEMP_GRAPHQL_ID\"}}}}";
 


### PR DESCRIPTION
# Description

Following discussion in #2166.
Fixes #2166.

For reference: https://github.com/FasterXML/jackson/blob/main/jackson3/MIGRATING_TO_JACKSON_3.md

These changes are only targeting the 2.x line since it may be considered as containing breaking changes and requires a minimum java version of Java 17.

# Before submitting a PR:

- [ ] Changes must not break binary backwards compatibility. If you are unclear on how to make the change you think is needed while maintaining backward compatibility, [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [x] Add JavaDocs and other comments explaining the behavior. 
- [x] When adding or updating methods that fetch entities, add `@link` JavaDoc entries to the relevant documentation on https://docs.github.com/en/rest . 
- [x] Add tests that cover any added or changed code. This generally requires capturing snapshot test data. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [x] Run `mvn -D enable-ci clean install site "-Dsurefire.argLine=--add-opens java.base/java.net=ALL-UNNAMED"` locally. If this command doesn't succeed, your change will not pass CI.
- [x] Push your changes to a branch other than `main`. You will create your PR from that branch.

# When creating a PR: 

- [x] Fill in the "Description" above with clear summary of the changes. This includes:
  - [x] If this PR fixes one or more issues, include "Fixes #<issue number>" lines for each issue. 
  - [x] Provide links to relevant documentation on https://docs.github.com/en/rest where possible. If not including links, explain why not.
- [x] All lines of new code should be covered by tests as reported by code coverage. Any lines that are not covered must have PR comments explaining why they cannot be covered. For example, "Reaching this particular exception is hard and is not a particular common scenario."
- [x] Enable "Allow edits from maintainers".
