### PR TITLE
feat: paginated gh pull request query builder

### DIFF
--- a/src/main/java/org/kohsuke/github/GHPullRequestQueryBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequestQueryBuilder.java
@@ -87,6 +87,18 @@ public class GHPullRequestQueryBuilder extends GHQueryBuilder<GHPullRequest> {
     }
 
     /**
+     * Page size gh pull request query builder.
+     *
+     * @param pageSize
+     *            the page size
+     * @return the gh pull request query builder
+     */
+    public GHPullRequestQueryBuilder pageSize(int pageSize) {
+        req.with("per_page", pageSize);
+        return this;
+    }
+
+    /**
      * Sort gh pull request query builder.
      *
      * @param sort

--- a/src/test/java/org/kohsuke/github/GHPullRequestTest.java
+++ b/src/test/java/org/kohsuke/github/GHPullRequestTest.java
@@ -729,6 +729,7 @@ public class GHPullRequestTest extends AbstractGitHubWireMockTest {
                 .state(GHIssueState.OPEN)
                 .head("hub4j-test-org:test/stable")
                 .base("main")
+                .pageSize(5)
                 .list()
                 .toList();
         assertThat(prs, notNullValue());

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/queryPullRequestsQualifiedHead/mappings/6-r_h_g_pulls.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/queryPullRequestsQualifiedHead/mappings/6-r_h_g_pulls.json
@@ -2,7 +2,7 @@
   "id": "ab74613d-0613-47a8-a6fc-34add77d9967",
   "name": "repos_hub4j-test-org_github-api_pulls",
   "request": {
-    "url": "/repos/hub4j-test-org/github-api/pulls?state=open&head=hub4j-test-org%3Atest%2Fstable&base=main",
+    "url": "/repos/hub4j-test-org/github-api/pulls?state=open&head=hub4j-test-org%3Atest%2Fstable&base=main&per_page=5",
     "method": "GET",
     "headers": {
       "Accept": {


### PR DESCRIPTION
# Description

* Fixes #2032 - (`GHPullRequestQueryBuilder` doesn't seem to support `pageSize(int)` but `GHIssueQueryBuilder` does)

https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests

# Before submitting a PR:

- [x] Changes must not break binary backwards compatibility. If you are unclear on how to make the change you think is needed while maintaining backward compatibility, [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [x] Add JavaDocs and other comments explaining the behavior. 
- [x] When adding or updating methods that fetch entities, add `@link` JavaDoc entries to the relevant documentation on https://docs.github.com/en/rest . 
- [x] Add tests that cover any added or changed code. This generally requires capturing snapshot test data. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [x] Run `mvn -D enable-ci clean install site "-Dsurefire.argLine=--add-opens java.base/java.net=ALL-UNNAMED"` locally. If this command doesn't succeed, your change will not pass CI.
- [x] Push your changes to a branch other than `main`. You will create your PR from that branch.

# When creating a PR: 

- [x] Fill in the "Description" above with clear summary of the changes. This includes:
  - [x] If this PR fixes one or more issues, include "Fixes #<issue number>" lines for each issue. 
  - [x] Provide links to relevant documentation on https://docs.github.com/en/rest where possible. If not including links, explain why not.
- [x] All lines of new code should be covered by tests as reported by code coverage. Any lines that are not covered must have PR comments explaining why they cannot be covered. For example, "Reaching this particular exception is hard and is not a particular common scenario."
- [x] Enable "Allow edits from maintainers".
