### PR TITLE
Add convertToDraft for pull requests

### DIFF
--- a/src/main/java/org/kohsuke/github/GHPullRequest.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequest.java
@@ -161,6 +161,30 @@ public class GHPullRequest extends GHIssue implements Refreshable {
     }
 
     /**
+     * Converts a pull request from ready for review to draft
+     *
+     * @throws IOException
+     *             the io exception
+     * @throws IllegalStateException
+     *             if the pull request is not a draft
+     */
+    public void convertToDraft() throws IOException {
+        if (draft) {
+            throw new IllegalStateException("Pull request is already a draft");
+        }
+
+        StringBuilder inputBuilder = new StringBuilder();
+        addParameter(inputBuilder, "pullRequestId", this.getNodeId());
+
+        String graphqlBody = "mutation ConvertToDraft { convertPullRequestToDraft(input: {" + inputBuilder
+                + "}) { pullRequest { id } } }";
+
+        root().createGraphQLRequest(graphqlBody).sendGraphQL();
+
+        refresh();
+    }
+
+    /**
      * Create review gh pull request review builder.
      *
      * @return the gh pull request review builder
@@ -275,6 +299,10 @@ public class GHPullRequest extends GHIssue implements Refreshable {
         return base;
     }
 
+    //
+    // details that are only available via get with ID
+    //
+
     /**
      * Gets changed files.
      *
@@ -286,10 +314,6 @@ public class GHPullRequest extends GHIssue implements Refreshable {
         populate();
         return changedFiles;
     }
-
-    //
-    // details that are only available via get with ID
-    //
 
     /**
      * Gets the closed by.

--- a/src/test/java/org/kohsuke/github/GHPullRequestTest.java
+++ b/src/test/java/org/kohsuke/github/GHPullRequestTest.java
@@ -226,6 +226,49 @@ public class GHPullRequestTest extends AbstractGitHubWireMockTest {
     }
 
     /**
+     * Test marking a draft pull request as ready for review.
+     *
+     * @throws Exception
+     *             the exception
+     */
+    @Test
+    public void convertToDraft() throws Exception {
+        // Create a draft PR first
+        GHPullRequest p = getRepository()
+                .createPullRequest("convertToDraft", "test/stable", "main", "## test", false, false);
+        assertThat(p.isDraft(), is(false));
+
+        // Mark it ready for review
+        p.convertToDraft();
+
+        // Verify it's no longer a draft
+        assertThat(p.isDraft(), is(true));
+    }
+
+    /**
+     * Test marking a draft pull request as ready for review.
+     *
+     * @throws Exception
+     *             the exception
+     */
+    @Test
+    public void convertToDraftFromDraft() throws Exception {
+        // Create a draft PR first
+        GHPullRequest p = getRepository()
+                .createPullRequest("convertToDraft", "test/stable", "main", "## test", false, true);
+        assertThat(p.isDraft(), is(true));
+
+        // Mark it ready for review
+        try {
+            p.convertToDraft();
+            fail("Expected IllegalStateException");
+        } catch (IllegalStateException e) {
+            assertThat(e.getMessage(), equalTo("Pull request is already a draft"));
+        }
+
+    }
+
+    /**
      * Creates the draft pull request.
      *
      * @throws Exception


### PR DESCRIPTION
# Description

Allow to convert a pull request to a draft if it is currently in `Ready for review`.
Similar to `markReadyForReview` it uses graphQL as the regular rest api doesn't support this.

https://docs.github.com/en/graphql/reference/mutations#convertpullrequesttodraft

fixes #2197


<!-- Describe your change here -->

# Before submitting a PR:

- [x] Changes must not break binary backwards compatibility. If you are unclear on how to make the change you think is needed while maintaining backward compatibility, [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [x] Add JavaDocs and other comments explaining the behavior. 
- [x] When adding or updating methods that fetch entities, add `@link` JavaDoc entries to the relevant documentation on https://docs.github.com/en/rest . 
- [x] Add tests that cover any added or changed code. This generally requires capturing snapshot test data. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [ ] Run `mvn -D enable-ci clean install site "-Dsurefire.argLine=--add-opens java.base/java.net=ALL-UNNAMED"` locally. If this command doesn't succeed, your change will not pass CI.
- [x] Push your changes to a branch other than `main`. You will create your PR from that branch.

# When creating a PR: 

- [x] Fill in the "Description" above with clear summary of the changes. This includes:
  - [x] If this PR fixes one or more issues, include "Fixes #<issue number>" lines for each issue. 
  - [x] Provide links to relevant documentation on https://docs.github.com/en/rest where possible. If not including links, explain why not.
- [x] All lines of new code should be covered by tests as reported by code coverage. Any lines that are not covered must have PR comments explaining why they cannot be covered. For example, "Reaching this particular exception is hard and is not a particular common scenario."
- [x] Enable "Allow edits from maintainers".
