### PR TITLE
Add missing setter methods to GHTeam

### DIFF
--- a/src/main/java/org/kohsuke/github/GHTeam.java
+++ b/src/main/java/org/kohsuke/github/GHTeam.java
@@ -511,6 +511,58 @@ public class GHTeam extends GHObject implements Refreshable {
         root().createRequest().method("PATCH").with("privacy", privacy).withUrlPath(api("")).send();
     }
 
+    /**
+     * Sets the team's name.
+     *
+     * @param name
+     *            the new name
+     * @throws IOException
+     *             the io exception
+     */
+    public void setName(String name) throws IOException {
+        root().createRequest().method("PATCH").with("name", name).withUrlPath(api("")).send();
+    }
+
+    /**
+     * Sets the team's notification setting.
+     *
+     * @param notificationSetting
+     *            the notification setting (e.g. "notifications_enabled" or "notifications_disabled")
+     * @throws IOException
+     *             the io exception
+     */
+    public void setNotificationSetting(String notificationSetting) throws IOException {
+        root().createRequest()
+                .method("PATCH")
+                .with("notification_setting", notificationSetting)
+                .withUrlPath(api(""))
+                .send();
+    }
+
+    /**
+     * Sets the team's permission.
+     *
+     * @param permission
+     *            the permission (e.g. "pull", "push", or "admin")
+     * @throws IOException
+     *             the io exception
+     */
+    public void setPermission(String permission) throws IOException {
+        root().createRequest().method("PATCH").with("permission", permission).withUrlPath(api("")).send();
+    }
+
+    /**
+     * Sets the team's parent team by ID.
+     *
+     * @param parentTeamId
+     *            the ID of the parent team, or {@code null} to remove the parent
+     * @throws IOException
+     *             the io exception
+     */
+    public void setParentTeamId(Long parentTeamId) throws IOException {
+        root().createRequest().method("PATCH").with("parent_team_id", parentTeamId).withUrlPath(api("")).send();
+    }
+
     private String api(String tail) {
         if (organization == null) {
             // Teams returned from pull requests to do not have an organization. Attempt to use url.

--- a/src/main/java/org/kohsuke/github/GHTeam.java
+++ b/src/main/java/org/kohsuke/github/GHTeam.java
@@ -35,6 +35,28 @@ public class GHTeam extends GHObject implements Refreshable {
     }
 
     /**
+     * Notification setting for a team. Controls whether members receive notifications when the team is mentioned.
+     */
+    public enum NotificationSetting {
+
+        /** Notifications enabled: members receive notifications when the team is @mentioned. */
+        NOTIFICATIONS_ENABLED("notifications_enabled"),
+        /** Notifications disabled: mentions of the team do not generate notifications. */
+        NOTIFICATIONS_DISABLED("notifications_disabled");
+
+        private final String apiValue;
+
+        NotificationSetting(String apiValue) {
+            this.apiValue = apiValue;
+        }
+
+        @Override
+        public String toString() {
+            return apiValue;
+        }
+    }
+
+    /**
      * Member's role in a team.
      */
     public enum Role {
@@ -527,14 +549,14 @@ public class GHTeam extends GHObject implements Refreshable {
      * Sets the team's notification setting.
      *
      * @param notificationSetting
-     *            the notification setting (e.g. "notifications_enabled" or "notifications_disabled")
+     *            the notification setting
      * @throws IOException
      *             the io exception
      */
-    public void setNotificationSetting(String notificationSetting) throws IOException {
+    public void setNotificationSetting(NotificationSetting notificationSetting) throws IOException {
         root().createRequest()
                 .method("PATCH")
-                .with("notification_setting", notificationSetting)
+                .with("notification_setting", notificationSetting.toString())
                 .withUrlPath(api(""))
                 .send();
     }
@@ -543,11 +565,11 @@ public class GHTeam extends GHObject implements Refreshable {
      * Sets the team's permission.
      *
      * @param permission
-     *            the permission (e.g. "pull", "push", or "admin")
+     *            the permission
      * @throws IOException
      *             the io exception
      */
-    public void setPermission(String permission) throws IOException {
+    public void setPermission(GHOrganization.Permission permission) throws IOException {
         root().createRequest().method("PATCH").with("permission", permission).withUrlPath(api("")).send();
     }
 


### PR DESCRIPTION
GHTeam currently only has `setDescription` and `setPrivacy`. The [GitHub API](https://docs.github.com/en/rest/teams/teams#update-a-team) supports updating several more properties.

This adds 4 missing setters, all following the same PATCH pattern as the existing ones:

- `setName(String name)`
- `setNotificationSetting(String notificationSetting)`
- `setPermission(String permission)`
- `setParentTeamId(Long parentTeamId)` (nullable, to support removing parent)

Each is a single PATCH call to the team endpoint. An atomic multi-property update builder could follow as a separate enhancement if maintainers want one.

Fixes #2218

This contribution was developed with AI assistance (Codex).