### PR TITLE
Fix GHCommitPointer null repository path and add regression test

### DIFF
--- a/src/main/java/org/kohsuke/github/GHCommitPointer.java
+++ b/src/main/java/org/kohsuke/github/GHCommitPointer.java
@@ -52,9 +52,21 @@ public class GHCommitPointer {
      * @throws IOException
      *             the io exception
      */
+
+    //original code
+    // public GHCommit getCommit() throws IOException {
+    //     return getRepository().getCommit(getSha()); //when repo is null, so this will throw NPE
+    // }
+
+    //fixed code
     public GHCommit getCommit() throws IOException {
-        return getRepository().getCommit(getSha());
+    GHRepository repository = getRepository();
+    if (repository == null) 
+        throw new IOException("Cannot commit because repository is null.");
+        
+        return repository.getCommit(getSha());
     }
+
 
     /**
      * String that looks like "USERNAME:REF".

--- a/src/main/java/org/kohsuke/github/GHPullRequest.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequest.java
@@ -340,7 +340,7 @@ public class GHPullRequest extends GHIssue implements Refreshable {
      * @return the head
      */
     public GHCommitPointer getHead() {
-        return head;
+        return head; //return head directly, no null check
     }
 
     /**

--- a/src/test/java/org/kohsuke/github/GHCommitPointerTest.java
+++ b/src/test/java/org/kohsuke/github/GHCommitPointerTest.java
@@ -1,0 +1,31 @@
+package org.kohsuke.github;
+
+import org.junit.Assert;
+import org.junit.Test;
+import java.io.IOException;
+
+public class GHCommitPointerTest {
+    //week8 failing test:
+    //test the null value
+    // @Test
+    // public void nullRepoNpe() throws Exception {
+
+    //     GHCommitPointer pointer = new GHCommitPointer(); //new object value is null
+    // 
+         // throws NPE because repository is null.
+    //     pointer.getCommit();
+    // }
+
+    //week9 fixed test
+    //test the IOException， which is more controllable
+    @Test
+    public void nullRepoNpe() {
+        GHCommitPointer pointer = new GHCommitPointer();
+
+        //expect throw IOException, test fail otherwise
+        IOException ex = Assert.assertThrows(IOException.class, pointer::getCommit); //method reference
+
+        //continue to test if error message also contains "repository is null", test fail otherwise
+        Assert.assertTrue(ex.getMessage().contains("repository is null"));
+    }
+}


### PR DESCRIPTION
Fix issue #2035: handle null repository in GHCommitPointer#getCommit and add regression test.

### What changed

1) `src/main/java/org/kohsuke/github/GHCommitPointer.java`
- Updated `getCommit()` to avoid an uncontrolled NullPointerException path.
- Added a local `repository` variable from `getRepository()`.
- Added a null guard:
  - If repository is null, throw `IOException("Cannot commit because repository is null.")`.
  - Otherwise continue with `repository.getCommit(getSha())`.

2) `src/test/java/org/kohsuke/github/GHCommitPointerTest.java` (new file)
- Added regression test `nullRepoNpe`.
- Test creates a `GHCommitPointer` with default null repository state.
- Verifies `getCommit()` now throws `IOException` (not NPE).
- Verifies exception message contains `"repository is null"`.

3) `src/main/java/org/kohsuke/github/GHPullRequest.java`
- Minor inline comment update in `getHead()` for debugging context.
- No functional logic change.

### Why
Issue #2035 reports an NPE when `GHCommitPointer#getCommit()` is called and repository data is missing.  
This change makes behavior explicit and controlled, and adds test coverage for the null-repository path.

### Validation
- Targeted test command:
  - `mvn -Dtest=GHCommitPointerTest#nullRepoNpe test`
- Result:
  - `Tests run: 1, Failures: 0, Errors: 0`
  - `BUILD SUCCESS`