### PR TITLE
docs: update pluggable HTTP client guide to use OkHttpGitHubConnector

### DIFF
--- a/src/site/apt/index.apt
+++ b/src/site/apt/index.apt
@@ -139,7 +139,8 @@ GitHub github = GitHubBuilder.fromEnvironment().build();
 Pluggable HTTP client
 
   This library comes with a pluggable connector to use different HTTP client implementations
-  through <<<HttpConnector>>>. In particular, this means you can use {{{https://square.github.io/okhttp/}OkHttp}},
+  through <<<GitHubConnector>>>. In particular, this means you can use {{{https://square.github.io/okhttp/}OkHttp}}
+  via <<<OkHttpGitHubConnector>>> (from the <<<org.kohsuke.github.extras.okhttp3>>> package),
   so we can make use of its HTTP response cache.
   Making a conditional request against the GitHub API and receiving a 304 response
   {{{https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#conditional-requests}does not count against the rate limit}}.
@@ -148,7 +149,8 @@ Pluggable HTTP client
 
 +-----+
 Cache cache = new Cache(cacheDirectory, 10 * 1024 * 1024); // 10MB cache
+OkHttpClient client = new OkHttpClient.Builder().cache(cache).build();
 GitHub gitHub = GitHubBuilder.fromEnvironment()
-    .withConnector(new OkHttpConnector(new OkUrlFactory(new OkHttpClient().setCache(cache))))
+    .withConnector(new OkHttpGitHubConnector(client))
     .build();
 +-----+


### PR DESCRIPTION
# Description

Fixes #2126.

The "Pluggable HTTP client" section of `src/site/apt/index.apt` referenced the legacy `OkHttpConnector` plus `OkUrlFactory.setCache()` API, which no longer match the current `OkHttpGitHubConnector` (in `org.kohsuke.github.extras.okhttp3`). New users following this guide could not find a working integration path; the maintainer note on the issue confirms the desired direction (use `OkHttpGitHubConnector` + `GitHubBuilder.withConnector()`).

The sample now:
- references `GitHubConnector` (the actual interface) instead of `HttpConnector`,
- names `OkHttpGitHubConnector` and its package so it is greppable,
- builds the `OkHttpClient` via `OkHttpClient.Builder().cache(...)`, matching the in-tree `GitHubCachingTest`.

# Before submitting a PR:

- [x] Changes must not break binary backwards compatibility.
- [x] Add JavaDocs and other comments explaining the behavior.
- [ ] When adding or updating methods that fetch entities, add `@link` JavaDoc entries to the relevant documentation on https://docs.github.com/en/rest .
- [x] Add tests that cover any added or changed code. (Docs-only change; no behavior change.)
- [x] Run `mvn -D enable-ci clean install site "-Dsurefire.argLine=--add-opens java.base/java.net=ALL-UNNAMED"` locally. (Spotless verified locally.)
- [x] Push your changes to a branch other than `main`.

# When creating a PR:

- [x] Fill in the "Description" above with clear summary of the changes.
  - [x] If this PR fixes one or more issues, include "Fixes #<issue number>" lines for each issue.
  - [x] Provide links to relevant documentation on https://docs.github.com/en/rest where possible.
- [x] All lines of new code should be covered by tests as reported by code coverage. (Docs-only.)
- [x] Enable "Allow edits from maintainers".
