### PR TITLE
Add `authorAssociation` field to `GHIssue`

### DIFF
--- a/src/main/java/org/kohsuke/github/GHIssue.java
+++ b/src/main/java/org/kohsuke/github/GHIssue.java
@@ -121,6 +121,9 @@ public class GHIssue extends GHObject implements Reactable {
     /** The assignees. */
     protected GHUser[] assignees;
 
+    /** The author's association with the repository. */
+    protected String authorAssociation;
+
     /** The body. */
     @SkipFromToString
     protected String body;
@@ -347,6 +350,17 @@ public class GHIssue extends GHObject implements Reactable {
      */
     public List<GHUser> getAssignees() {
         return Collections.unmodifiableList(Arrays.asList(assignees));
+    }
+
+    /**
+     * Gets the author's association with the repository.
+     *
+     * @return the author association
+     */
+    public GHCommentAuthorAssociation getAuthorAssociation() {
+        return EnumUtils.getEnumOrDefault(GHCommentAuthorAssociation.class,
+                authorAssociation,
+                GHCommentAuthorAssociation.UNKNOWN);
     }
 
     /**

--- a/src/test/java/org/kohsuke/github/GHIssueTest.java
+++ b/src/test/java/org/kohsuke/github/GHIssueTest.java
@@ -169,6 +169,7 @@ public class GHIssueTest extends AbstractGitHubWireMockTest {
         GHRepository repo = getRepository();
         GHIssue issue = repo.createIssue(name).body("## test").create();
         assertThat(issue.getTitle(), equalTo(name));
+        assertThat(issue.getAuthorAssociation(), equalTo(GHCommentAuthorAssociation.NONE));
     }
 
     /**


### PR DESCRIPTION
# Description

Deserialize the `author_association` field from the GitHub REST API on issues and pull requests. Uses the same String-field + EnumUtils pattern as GHIssueComment for forward-compatible enum parsing.

# Before submitting a PR:

- [x] Changes must not break binary backwards compatibility. If you are unclear on how to make the change you think is needed while maintaining backward compatibility, [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [x] Add JavaDocs and other comments explaining the behavior. 
- [x] When adding or updating methods that fetch entities, add `@link` JavaDoc entries to the relevant documentation on https://docs.github.com/en/rest . 
- [x] Add tests that cover any added or changed code. This generally requires capturing snapshot test data. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [x] Run `mvn -D enable-ci clean install site "-Dsurefire.argLine=--add-opens java.base/java.net=ALL-UNNAMED"` locally. If this command doesn't succeed, your change will not pass CI.
- [x] Push your changes to a branch other than `main`. You will create your PR from that branch.

# When creating a PR: 

- [x] Fill in the "Description" above with clear summary of the changes. This includes:
  - [x] If this PR fixes one or more issues, include "Fixes #<issue number>" lines for each issue. 
  - [x] Provide links to relevant documentation on https://docs.github.com/en/rest where possible. If not including links, explain why not.
- [x] All lines of new code should be covered by tests as reported by code coverage. Any lines that are not covered must have PR comments explaining why they cannot be covered. For example, "Reaching this particular exception is hard and is not a particular common scenario."
- [x] Enable "Allow edits from maintainers".
