### PR TITLE
Support new issue types

### DIFF
--- a/src/main/java/org/kohsuke/github/GHIssue.java
+++ b/src/main/java/org/kohsuke/github/GHIssue.java
@@ -161,6 +161,9 @@ public class GHIssue extends GHObject implements Reactable {
     /** The html url. */
     protected String title, htmlUrl;
 
+    /** The issue type. */
+    protected GHIssueType type;
+
     /** The user. */
     protected GHUser user;
 
@@ -520,6 +523,16 @@ public class GHIssue extends GHObject implements Reactable {
     }
 
     /**
+     * Gets the issue type.
+     *
+     * @return the issue type, or {@code null} if no type is assigned
+     */
+    @SuppressFBWarnings(value = { "EI_EXPOSE_REP" }, justification = "Expected behavior")
+    public GHIssueType getType() {
+        return type;
+    }
+
+    /**
      * User who submitted the issue.
      *
      * @return the user
@@ -782,6 +795,18 @@ public class GHIssue extends GHObject implements Reactable {
      */
     public void setTitle(String title) throws IOException {
         edit("title", title);
+    }
+
+    /**
+     * Sets the issue type.
+     *
+     * @param type
+     *            the issue type name, or {@code null} to remove the current type
+     * @throws IOException
+     *             the io exception
+     */
+    public void setType(String type) throws IOException {
+        editIssue("type", type);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHIssueBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHIssueBuilder.java
@@ -108,4 +108,17 @@ public class GHIssueBuilder {
             builder.with("milestone", milestone.getNumber());
         return this;
     }
+
+    /**
+     * Assigns an issue type by name.
+     *
+     * @param type
+     *            the issue type name
+     * @return the gh issue builder
+     */
+    public GHIssueBuilder type(String type) {
+        if (type != null)
+            builder.with("type", type);
+        return this;
+    }
 }

--- a/src/main/java/org/kohsuke/github/GHIssueType.java
+++ b/src/main/java/org/kohsuke/github/GHIssueType.java
@@ -1,0 +1,60 @@
+package org.kohsuke.github;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+/**
+ * Represents an issue type configured for a GitHub organization.
+ *
+ * @see GHOrganization#listIssueTypes() GHOrganization#listIssueTypes()
+ * @see <a href="https://docs.github.com/en/rest/orgs/issue-types">Issue types API</a>
+ */
+@SuppressFBWarnings(value = { "UWF_UNWRITTEN_FIELD" }, justification = "JSON API")
+public class GHIssueType extends GHObject {
+
+    private String color;
+    private String description;
+    private boolean isEnabled;
+    private String name;
+
+    /**
+     * Create default GHIssueType instance.
+     */
+    public GHIssueType() {
+    }
+
+    /**
+     * Gets the issue type color.
+     *
+     * @return the color
+     */
+    public String getColor() {
+        return color;
+    }
+
+    /**
+     * Gets the issue type description.
+     *
+     * @return the description
+     */
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * Gets the issue type name.
+     *
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Returns whether the issue type is enabled.
+     *
+     * @return {@code true} if enabled
+     */
+    public boolean isEnabled() {
+        return isEnabled;
+    }
+}

--- a/src/main/java/org/kohsuke/github/GHOrganization.java
+++ b/src/main/java/org/kohsuke/github/GHOrganization.java
@@ -507,6 +507,19 @@ public class GHOrganization extends GHPerson {
     }
 
     /**
+     * Lists the issue types configured for this organization.
+     *
+     * @return the issue types
+     * @see <a href="https://docs.github.com/en/rest/orgs/issue-types#list-issue-types-for-an-organization">List issue
+     *      types for an organization</a>
+     */
+    public PagedIterable<GHIssueType> listIssueTypes() {
+        return root().createRequest()
+                .withUrlPath(String.format("/orgs/%s/issue-types", login))
+                .toIterable(GHIssueType[].class, null);
+    }
+
+    /**
      * All the members of this organization.
      *
      * @return the paged iterable

--- a/src/main/resources/META-INF/native-image/org.kohsuke/github-api/reflect-config.json
+++ b/src/main/resources/META-INF/native-image/org.kohsuke/github-api/reflect-config.json
@@ -3300,6 +3300,21 @@
     "allDeclaredClasses": true
   },
   {
+    "name": "org.kohsuke.github.GHIssueType",
+    "allPublicFields": true,
+    "allDeclaredFields": true,
+    "queryAllPublicConstructors": true,
+    "queryAllDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredConstructors": true,
+    "queryAllPublicMethods": true,
+    "queryAllDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredMethods": true,
+    "allPublicClasses": true,
+    "allDeclaredClasses": true
+  },
+  {
     "name": "org.kohsuke.github.GHKey",
     "allPublicFields": true,
     "allDeclaredFields": true,

--- a/src/main/resources/META-INF/native-image/org.kohsuke/github-api/serialization-config.json
+++ b/src/main/resources/META-INF/native-image/org.kohsuke/github-api/serialization-config.json
@@ -660,6 +660,9 @@
     "name": "org.kohsuke.github.GHIssueStateReason"
   },
   {
+    "name": "org.kohsuke.github.GHIssueType"
+  },
+  {
     "name": "org.kohsuke.github.GHKey"
   },
   {

--- a/src/test/java/org/kohsuke/github/GHIssueTypeApiTest.java
+++ b/src/test/java/org/kohsuke/github/GHIssueTypeApiTest.java
@@ -1,0 +1,83 @@
+package org.kohsuke.github;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.RETURNS_SELF;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests the API request construction for issue types.
+ */
+public class GHIssueTypeApiTest {
+
+    /**
+     * Verifies that creating an issue can include an issue type.
+     */
+    @Test
+    public void createsIssueWithType() {
+        GitHub gitHub = mock(GitHub.class);
+        Requester requester = mock(Requester.class, RETURNS_SELF);
+        GHRepository repository = mock(GHRepository.class);
+        when(gitHub.createRequest()).thenReturn(requester);
+        doReturn(gitHub).when(repository).root();
+
+        GHIssueBuilder builder = new GHIssueBuilder(repository, "Typed issue");
+
+        assertThat(builder.type("Bug"), sameInstance(builder));
+        assertThat(builder.type(null), sameInstance(builder));
+        verify(requester).with("type", "Bug");
+    }
+
+    /**
+     * Verifies the organization issue type endpoint and response type.
+     */
+    @Test
+    public void listsOrganizationIssueTypes() {
+        GitHub gitHub = mock(GitHub.class);
+        Requester requester = mock(Requester.class, RETURNS_SELF);
+        GHOrganization organization = mock(GHOrganization.class, CALLS_REAL_METHODS);
+        @SuppressWarnings("unchecked")
+        PagedIterable<GHIssueType> issueTypes = mock(PagedIterable.class);
+        when(gitHub.createRequest()).thenReturn(requester);
+        doReturn(gitHub).when(organization).root();
+        organization.login = "hub4j";
+        when(requester.toIterable(eq(GHIssueType[].class), isNull())).thenReturn(issueTypes);
+
+        assertThat(organization.listIssueTypes(), sameInstance(issueTypes));
+        verify(requester).withUrlPath("/orgs/hub4j/issue-types");
+        verify(requester).toIterable(eq(GHIssueType[].class), isNull());
+    }
+
+    /**
+     * Verifies that an existing issue type can be changed.
+     *
+     * @throws IOException
+     *             if updating the issue fails
+     */
+    @Test
+    public void setsIssueType() throws IOException {
+        GitHub gitHub = mock(GitHub.class);
+        Requester requester = mock(Requester.class, RETURNS_SELF);
+        GHIssue issue = mock(GHIssue.class, CALLS_REAL_METHODS);
+        when(gitHub.createRequest()).thenReturn(requester);
+        doReturn(gitHub).when(issue).root();
+        doReturn("/repos/hub4j/github-api/issues/2010").when(issue).getIssuesApiRoute();
+
+        issue.setType("Bug");
+
+        verify(requester).withNullable("type", "Bug");
+        verify(requester).method("PATCH");
+        verify(requester).withUrlPath("/repos/hub4j/github-api/issues/2010");
+        verify(requester).send();
+    }
+}

--- a/src/test/java/org/kohsuke/github/GHIssueTypeTest.java
+++ b/src/test/java/org/kohsuke/github/GHIssueTypeTest.java
@@ -1,0 +1,58 @@
+package org.kohsuke.github;
+
+import org.junit.Test;
+
+import java.time.Instant;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Unit tests for {@link GHIssueType}.
+ */
+public class GHIssueTypeTest {
+
+    /**
+     * Verifies issue type JSON mapping on both the issue and the issue type model.
+     *
+     * @throws Exception
+     *             if JSON mapping fails
+     */
+    @Test
+    public void mapsIssueTypeFromIssueResponse() throws Exception {
+        String json = "{" + "\"id\":1," + "\"number\":42," + "\"title\":\"Typed issue\"," + "\"type\":{"
+                + "\"id\":1001," + "\"node_id\":\"IT_kwDOBb4AAAAAA-k5\"," + "\"name\":\"Bug\","
+                + "\"description\":\"An unexpected problem or behavior\"," + "\"color\":\"red\","
+                + "\"created_at\":\"2025-03-18T12:00:00Z\"," + "\"updated_at\":\"2025-03-19T12:00:00Z\","
+                + "\"is_enabled\":true}" + "}";
+
+        GHIssue issue = GitHub.getMappingObjectReader().forType(GHIssue.class).readValue(json);
+        GHIssueType type = issue.getType();
+
+        assertThat(type.getId(), equalTo(1001L));
+        assertThat(type.getNodeId(), equalTo("IT_kwDOBb4AAAAAA-k5"));
+        assertThat(type.getName(), equalTo("Bug"));
+        assertThat(type.getDescription(), equalTo("An unexpected problem or behavior"));
+        assertThat(type.getColor(), equalTo("red"));
+        assertThat(type.isEnabled(), is(true));
+        assertThat(type.getCreatedAt(), equalTo(Instant.parse("2025-03-18T12:00:00Z")));
+        assertThat(type.getUpdatedAt(), equalTo(Instant.parse("2025-03-19T12:00:00Z")));
+    }
+
+    /**
+     * Verifies an issue without an assigned type remains backwards compatible.
+     *
+     * @throws Exception
+     *             if JSON mapping fails
+     */
+    @Test
+    public void mapsIssueWithoutType() throws Exception {
+        GHIssue issue = GitHub.getMappingObjectReader()
+                .forType(GHIssue.class)
+                .readValue("{\"id\":1,\"number\":42,\"title\":\"Untyped issue\",\"type\":null}");
+
+        assertThat(issue.getType(), nullValue());
+    }
+}


### PR DESCRIPTION
# Description

Adds support for GitHub issue types.

This change:

- Introduces `GHIssueType` with name, description, color, and enabled properties.
- Exposes the issue type on `GHIssue` through `getType()`.
- Adds `GHIssueBuilder.type(String)` for setting the type when creating an issue.
- Adds `GHOrganization.listIssueTypes()` for listing the issue types configured for an organization.
- Registers `GHIssueType` for native-image reflection and serialization.
- Adds tests for mapping issue responses both with and without an issue type.

Fixes #2010

Relevant GitHub REST API documentation:

- https://docs.github.com/en/rest/orgs/issue-types#list-issue-types-for-an-organization
- https://docs.github.com/en/rest/issues/issues#create-an-issue

## Testing

The issue type and AOT integration tests pass with Java 17:

```text
Tests run: 3
Failures: 0
Errors: 0
Skipped: 0
BUILD SUCCESS
```

The full Maven build was attempted locally on Windows, but it did not complete successfully because of unrelated existing tests, including  `AppTest.testCommitSearch`  and locale-sensitive HTTP date tests. No changes related to those failures are included in this PR. The relevant issue type and AOT tests pass.

# Before submitting a PR:

- [x] Changes must not break binary backwards compatibility. If you are unclear on how to make the change you think is needed while maintaining backward compatibility, [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [x] Add JavaDocs and other comments explaining the behavior.
- [x] When adding or updating methods that fetch entities, add `@link` JavaDoc entries to the relevant documentation on https://docs.github.com/en/rest .
- [ ] Add tests that cover any added or changed code. This generally requires capturing snapshot test data. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [ ] Run `mvn -D enable-ci clean install site "-Dsurefire.argLine=--add-opens java.base/java.net=ALL-UNNAMED"` locally. If this command doesn't succeed, your change will not pass CI.
- [x] Push your changes to a branch other than `main`. You will create your PR from that branch.

# When creating a PR:

- [x] Fill in the "Description" above with clear summary of the changes. This includes:
  - [x] If this PR fixes one or more issues, include "Fixes #<issue number>" lines for each issue.
  - [x] Provide links to relevant documentation on https://docs.github.com/en/rest where possible. If not including links, explain why not.
- [ ] All lines of new code should be covered by tests as reported by code coverage. Any lines that are not covered must have PR comments explaining why they cannot be covered. For example, "Reaching this particular exception is hard and is not a particular common scenario."
- [x] Enable "Allow edits from maintainers".